### PR TITLE
refactor: MLIBZ-1860 Improving the error message strings

### DIFF
--- a/android-lib/src/main/java/com/kinvey/android/push/GCMPush.java
+++ b/android-lib/src/main/java/com/kinvey/android/push/GCMPush.java
@@ -84,7 +84,7 @@ public class GCMPush extends AbstractPush {
     @Override
     public GCMPush initialize(final Application currentApp) {
         if (!getClient().isUserLoggedIn()) {
-            throw new KinveyException("No user is currently logged in", "call myClient.User().login(...) first to login", "Registering for Push Notifications needs a logged in user");
+            throw new KinveyException("No user is currently logged in", "call UserStore.login(...) first to login", "Registering for Push Notifications needs a logged in user");
         }
         
         if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(currentApp) != ConnectionResult.SUCCESS){

--- a/java-api-core/src/com/kinvey/java/core/KinveyClientRequestInitializer.java
+++ b/java-api-core/src/com/kinvey/java/core/KinveyClientRequestInitializer.java
@@ -101,9 +101,9 @@ public class KinveyClientRequestInitializer implements KinveyRequestInitializer 
      */
     public void initialize(AbstractKinveyClientRequest<?> request) {
         if (!request.isRequireAppCredentials()){
-            Preconditions.checkNotNull(credential, "No Active User - please login a user by calling myClient.user().login( ... ) before retrying this request.");
-            Preconditions.checkNotNull(credential.getUserId(), "No Active User - please login a user by calling myClient.user().login( ... ) before retrying this request.");
-            Preconditions.checkNotNull(credential.getAuthToken(), "No Active User - please login a user by calling myClient.user().login( ... ) before retrying this request.");
+            Preconditions.checkNotNull(credential, "No Active User - please login a user by calling UserStore.login( ... ) before retrying this request.");
+            Preconditions.checkNotNull(credential.getUserId(), "No Active User - please login a user by calling UserStore.login( ... ) before retrying this request.");
+            Preconditions.checkNotNull(credential.getAuthToken(), "No Active User - please login a user by calling UserStore.login( ... ) before retrying this request.");
         }
 
         if (credential != null && !request.isRequireAppCredentials()) {


### PR DESCRIPTION
#### Description
Incorrect error text if trying to initialize GCM and user is not logged in or initialize KinveyClientRequest when app credentials are not required (https://kinvey.atlassian.net/browse/MLIBZ-1860)

#### Changes
Update text in error messages, since it goes through the UserStore now

#### Tests
Manual
