### PR TITLE
fix: MLIBZ-1883 Missed flag in 'user-forgot-username' and 'check-username-exists' requests

### DIFF
--- a/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
@@ -470,7 +470,7 @@ public class UserStore {
         new ResetPassword(usernameOrEmail, client, callback).execute();
     }
 
-    public static void exists(String username, AbstractClient client, KinveyUserManagementCallback callback) {
+    public static void exists(String username, AbstractClient client, KinveyClientCallback<Boolean> callback) {
         new ExistsUser(username, client, callback).execute();
     }
 
@@ -1107,13 +1107,13 @@ public class UserStore {
         }
     }
 
-    private static class ExistsUser extends AsyncClientRequest<Void> {
+    private static class ExistsUser extends AsyncClientRequest<Boolean> {
 
         String username;
         private final AbstractClient client;
 
 
-        private ExistsUser(String username, AbstractClient client, KinveyClientCallback<Void> callback) {
+        private ExistsUser(String username, AbstractClient client, KinveyClientCallback<Boolean> callback) {
             super(callback);
             this.username = username;
             this.client = client;
@@ -1121,9 +1121,8 @@ public class UserStore {
         }
 
         @Override
-        protected Void executeAsync() throws IOException {
-            BaseUserStore.exists(username, client);
-            return null;
+        protected Boolean executeAsync() throws IOException {
+            return BaseUserStore.exists(username, client);
         }
     }
 

--- a/java-api-core/src/com/kinvey/java/dto/UserNameExists.java
+++ b/java-api-core/src/com/kinvey/java/dto/UserNameExists.java
@@ -10,7 +10,7 @@ public class UserNameExists {
     @Key("usernameExists")
     private boolean usernameExists;
 
-    public boolean isUsernameExists() {
+    public boolean doesUsernameExist() {
         return usernameExists;
     }
 

--- a/java-api-core/src/com/kinvey/java/dto/UserNameExists.java
+++ b/java-api-core/src/com/kinvey/java/dto/UserNameExists.java
@@ -1,0 +1,20 @@
+package com.kinvey.java.dto;
+
+import com.google.api.client.util.Key;
+
+/**
+ * Created by yuliya on 06/01/17.
+ */
+
+public class UserNameExists {
+    @Key("usernameExists")
+    private boolean usernameExists;
+
+    public boolean isUsernameExists() {
+        return usernameExists;
+    }
+
+    public void setUsernameExists(boolean usernameExists) {
+        this.usernameExists = usernameExists;
+    }
+}

--- a/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
@@ -125,7 +125,7 @@ public abstract class BaseUserStore <T extends User> {
     }
 
     public static boolean exists( String username, AbstractClient client) throws IOException {
-        return new UserStoreRequestManager(client, createBuilder(client)).exists(username).execute().isUsernameExists();
+        return new UserStoreRequestManager(client, createBuilder(client)).exists(username).execute().doesUsernameExist();
     }
 
     public static <T extends User> T get(String userId, AbstractClient client) throws IOException {

--- a/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
@@ -125,7 +125,7 @@ public abstract class BaseUserStore <T extends User> {
     }
 
     public static boolean exists( String username, AbstractClient client) throws IOException {
-        return new UserStoreRequestManager(client, createBuilder(client)).exists(username).execute();
+        return new UserStoreRequestManager(client, createBuilder(client)).exists(username).execute().isUsernameExists();
     }
 
     public static <T extends User> T get(String userId, AbstractClient client) throws IOException {

--- a/java-api-core/src/com/kinvey/java/store/requests/user/ForgotUsername.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/user/ForgotUsername.java
@@ -26,5 +26,6 @@ public final class ForgotUsername extends AbstractKinveyJsonClientRequest<Void> 
 
     public ForgotUsername(AbstractClient client, Email email) {
         super(client, "POST", REST_PATH, email, Void.class);
+        this.setRequireAppCredentials(true);
     }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/user/UserExists.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/user/UserExists.java
@@ -19,13 +19,14 @@ package com.kinvey.java.store.requests.user;
 import com.google.api.client.json.GenericJson;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
-import com.kinvey.java.dto.User;
+import com.kinvey.java.dto.UserNameExists;
 
 
-public final class UserExists extends AbstractKinveyJsonClientRequest<Boolean> {
+public final class UserExists extends AbstractKinveyJsonClientRequest<UserNameExists> {
     private static final String REST_PATH = "rpc/{appKey}/check-username-exists";
 
     public UserExists(AbstractClient client, GenericJson username) {
-        super(client, "POST", REST_PATH, username, Boolean.class);
+        super(client, "POST", REST_PATH, username, UserNameExists.class);
+        this.setRequireAppCredentials(true);
     }
 }


### PR DESCRIPTION
#### Description
Add 'requireAppCredentials' flag to 'user-forgot-username' and 'check-username-exists' requests. Improve tests accordingly.
(https://kinvey.atlassian.net/browse/MLIBZ-1883)

#### Changes
Added 'requireAppCredentials' to requests, added new DTO for 'check-username-exists' response.

#### Tests
JUnit
