### PR TITLE
fix: MLIBZ-1888 Crash while uploading file with InputStream

### DIFF
--- a/java-api-core/src/com/kinvey/java/store/BaseFileStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseFileStore.java
@@ -174,13 +174,14 @@ public class BaseFileStore {
                 metadata = upload.execute();
                 break;
             case LOCAL_THEN_NETWORK:
+                saveCacheFile(is, fileMetadataWithPath);
                 try {
                     metadata = upload.execute();
                 } catch (Exception e){
                     e.printStackTrace();
                 }
                 fileMetadataWithPath.putAll(metadata);
-                saveCacheFile(is, fileMetadataWithPath);
+                cache.save(fileMetadataWithPath);
                 break;
         }
 


### PR DESCRIPTION
#### Description
When trying to upload a file with StoreType.CACHE and InputStream in parameters, getting an exception.

#### Changes
Save to cache before InputStream is closed.

#### Tests
JUnit
