### PR TITLE
fix: MLIBZ-1893 File can't be downloaded if its size is zero

### DIFF
--- a/java-api-core/src/com/kinvey/java/core/MediaHttpDownloader.java
+++ b/java-api-core/src/com/kinvey/java/core/MediaHttpDownloader.java
@@ -270,7 +270,7 @@ public class MediaHttpDownloader {
             }
 
             // set Range header (if necessary)
-            if (bytesDownloaded != 0 || currentRequestLastBytePos != -1) {
+            if (metaData.getSize() != 0 && (bytesDownloaded != 0 || currentRequestLastBytePos != -1)) {
                 StringBuilder rangeHeader = new StringBuilder();
                 rangeHeader.append("bytes=").append(bytesDownloaded).append("-");
                 if (currentRequestLastBytePos != -1) {


### PR DESCRIPTION
#### Description
File couldn't be downloaded if its size is zero. Got '416 Requested range not satisfiable' and the download was looping because of retrying to send new requests.

#### Changes
Check metadata size and don't add range header if it's empty.

#### Tests
JUnit
