### PR TITLE
Replaced a few links leading to public_beta with up-to-date links.

### DIFF
--- a/android-lib/javadoc/overview.html
+++ b/android-lib/javadoc/overview.html
@@ -24,14 +24,14 @@ Welcome to v3 of the Kinvey Android library.
     <li> <strong>Push Notifications</strong> Our library uses GCM integration which gives you awesome push features without the headache of managing them yourself.</li>
 </ul>
 
-<p>For more details on how to use these features read the <a href="http://devcenter.kinvey.com/android-v3.0_private_beta/guides">Kinvey Android Guides</a>.</p>
+<p>For more details on how to use these features read the <a href="http://devcenter.kinvey.com/android/guides">Kinvey Android Guides</a>.</p>
 
 <h1>Other Documentation</h1>
 
 <ul>
-    <li> For an overview of the service, see the <a href="http://devcenter.kinvey.com/android-v3.0_private_beta/guides">Kinvey Android Guides</a>.</li>
-    <li> For a quickstart, see the <a href="http://devcenter.kinvey.com/android-v3.0_private_beta/guides/getting-started">Android Getting Started</a>.</li>
-    <li> If you prefer working from sample applications see <a href="http://devcenter.kinvey.com/android-v3.0_private_beta/samples">Kinvey's Android Samples</a>.</li>
+    <li> For an overview of the service, see the <a href="http://devcenter.kinvey.com/android/guides">Kinvey Android Guides</a>.</li>
+    <li> For a quickstart, see the <a href="http://devcenter.kinvey.com/android/guides/getting-started">Android Getting Started</a>.</li>
+    <li> If you prefer working from sample applications see <a href="http://devcenter.kinvey.com/android/samples">Kinvey's Android Samples</a>.</li>
 </ul>
 
 </body>


### PR DESCRIPTION
#### Description
An update relating to documentation. Fixes broken links in the Java Doc.

#### Changes
Updates dead links in android-lib/javadoc/overview.html.

#### Tests
Manual test of the links inside the HTML.
