### PR TITLE
fix: MLIBZ-1945 Android SDK sends empty query object on get all

### DIFF
--- a/java-api-core/src/com/kinvey/java/network/LinkedNetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/LinkedNetworkManager.java
@@ -311,7 +311,7 @@ public class LinkedNetworkManager<T extends LinkedGenericJson> extends NetworkMa
      */
     public class Get extends GetLinkedResourceClientRequest<List<T>> {
 
-        private static final String REST_PATH = "appdata/{appKey}/{collectionName}/" +
+        private static final String REST_PATH = "appdata/{appKey}/{collectionName}" +
                 "{?query,sort,limit,skip,resolve,resolve_depth,retainReference}";
 
         private String[] attachments;

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -506,8 +506,7 @@ public class NetworkManager<T extends GenericJson> {
 
         MetadataGet(DeltaGet getRequest){
             super(client, "GET", REST_PATH, null, DeltaSetItem[].class);
-            String queryFilterString = getRequest.queryFilter;
-            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
+            this.queryFilter = getRequest.queryFilter;
 
             this.skip = getRequest.skip;
             this.limit = getRequest.limit;

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -641,8 +641,7 @@ public class NetworkManager<T extends GenericJson> {
         Get(Query query, Class myClass) {
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
-            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
-            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
+            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;
@@ -659,8 +658,7 @@ public class NetworkManager<T extends GenericJson> {
         Get(Query query, Class myClass, String[] resolves, int resolve_depth, boolean retain){
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
-            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
-            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
+            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;
@@ -820,8 +818,7 @@ public class NetworkManager<T extends GenericJson> {
         Delete(Query query) {
             super(client, "DELETE", REST_PATH, null, KinveyDeleteResponse.class);
             this.collectionName= NetworkManager.this.collectionName;
-            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
-            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
+            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -506,10 +506,8 @@ public class NetworkManager<T extends GenericJson> {
 
         MetadataGet(DeltaGet getRequest){
             super(client, "GET", REST_PATH, null, DeltaSetItem[].class);
-            this.queryFilter = getRequest.queryFilter;
-            if (this.queryFilter.equals("{}")) {
-                this.queryFilter = null;
-            }
+            String queryFilterString = getRequest.queryFilter;
+            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
 
             this.skip = getRequest.skip;
             this.limit = getRequest.limit;
@@ -643,10 +641,8 @@ public class NetworkManager<T extends GenericJson> {
         Get(Query query, Class myClass) {
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
-            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
-            if (this.queryFilter.equals("{}")) {
-                this.queryFilter = null;
-            }
+            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
+            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;
@@ -663,10 +659,8 @@ public class NetworkManager<T extends GenericJson> {
         Get(Query query, Class myClass, String[] resolves, int resolve_depth, boolean retain){
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
-            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
-            if (this.queryFilter.equals("{}")) {
-                this.queryFilter = null;
-            }
+            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
+            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;
@@ -687,7 +681,7 @@ public class NetworkManager<T extends GenericJson> {
         Get(String queryString, Class myClass){
         	super(client, "GET", REST_PATH, null, myClass);
         	this.collectionName= NetworkManager.this.collectionName;
-        	this.queryFilter = queryString;
+        	this.queryFilter = !queryString.equals("{}") ? queryString : null;
         	this.setTemplateExpand(false);
         	this.getRequestHeaders().put("X-Kinvey-Client-App-Version", NetworkManager.this.clientAppVersion);
             if (NetworkManager.this.customRequestProperties != null && !NetworkManager.this.customRequestProperties.isEmpty()){
@@ -826,7 +820,8 @@ public class NetworkManager<T extends GenericJson> {
         Delete(Query query) {
             super(client, "DELETE", REST_PATH, null, KinveyDeleteResponse.class);
             this.collectionName= NetworkManager.this.collectionName;
-            this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
+            String queryFilterString = query.getQueryFilterJson(client.getJsonFactory());
+            this.queryFilter = !queryFilterString.equals("{}") ? queryFilterString : null;
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -484,7 +484,7 @@ public class NetworkManager<T extends GenericJson> {
     
     
     private class MetadataGet extends AbstractKinveyJsonClientRequest<DeltaSetItem[]>{
-        private static final String REST_PATH = "appdata/{appKey}/{collectionName}/" +
+        private static final String REST_PATH = "appdata/{appKey}/{collectionName}" +
                 "{?query,fields,tls,sort,limit,skip,resolve,resolve_depth,retainReference}";
         @Key
         private String collectionName;
@@ -507,7 +507,9 @@ public class NetworkManager<T extends GenericJson> {
         MetadataGet(DeltaGet getRequest){
             super(client, "GET", REST_PATH, null, DeltaSetItem[].class);
             this.queryFilter = getRequest.queryFilter;
-
+            if (this.queryFilter.equals("{}")) {
+                this.queryFilter = null;
+            }
 
             this.skip = getRequest.skip;
             this.limit = getRequest.limit;
@@ -541,7 +543,7 @@ public class NetworkManager<T extends GenericJson> {
 
         private static final int IDS_PER_PAGE = 100;
 
-        private static final String REST_PATH = "appdata/{appKey}/{collectionName}/" +
+        private static final String REST_PATH = "appdata/{appKey}/{collectionName}" +
                 "{?query,sort,limit,skip,resolve,resolve_depth,retainReference}";
         private List<T> currentItems;
 
@@ -617,7 +619,7 @@ public class NetworkManager<T extends GenericJson> {
      */
     public class Get extends AbstractKinveyJsonClientRequest<T[]> {
 
-        private static final String REST_PATH = "appdata/{appKey}/{collectionName}/" +
+        private static final String REST_PATH = "appdata/{appKey}/{collectionName}" +
                 "{?query,sort,limit,skip,resolve,resolve_depth,retainReference}";
 
         @Key
@@ -642,6 +644,9 @@ public class NetworkManager<T extends GenericJson> {
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
             this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
+            if (this.queryFilter.equals("{}")) {
+                this.queryFilter = null;
+            }
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;
@@ -659,6 +664,9 @@ public class NetworkManager<T extends GenericJson> {
             super(client, "GET", REST_PATH, null, myClass);
             this.collectionName= NetworkManager.this.collectionName;
             this.queryFilter = query.getQueryFilterJson(client.getJsonFactory());
+            if (this.queryFilter.equals("{}")) {
+                this.queryFilter = null;
+            }
             int queryLimit = query.getLimit();
             int querySkip = query.getSkip();
             this.limit = queryLimit > 0 ? Integer.toString(queryLimit) : null;

--- a/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
+++ b/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
@@ -102,6 +102,10 @@ public abstract class AbstractQuery implements Serializable{
             jsonResult = writer.toString();
         } catch (Exception ex) {}
 
+        if (jsonResult.equals("{}")) {
+            return null;
+        }
+
         // TODO:  Put exception here?
 
         return jsonResult;


### PR DESCRIPTION
#### Description
Don't send empty query object

#### Changes
Remove sending empty query object

#### Tests
Instrumented
