### PR TITLE
Feature/mlibz 2107 implement automatic pagination

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheRealDataTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheRealDataTest.java
@@ -9,6 +9,7 @@ import android.test.suitebuilder.annotation.SmallTest;
 import com.kinvey.android.Client;
 import com.kinvey.android.store.DataStore;
 import com.kinvey.androidTest.TestManager;
+import com.kinvey.androidTest.callback.DefaultKinveyClientCallback;
 import com.kinvey.androidTest.callback.CustomKinveyClientCallback;
 import com.kinvey.androidTest.callback.CustomKinveyListCallback;
 import com.kinvey.androidTest.callback.CustomKinveyPullCallback;
@@ -395,6 +396,242 @@ public class CacheRealDataTest {
 
         assertNotNull(firstPerson);
         assertTrue(firstPerson.getId().equals(person3.getId()));
+    }
+
+    @Test
+    public void testDeleteMethod() throws InterruptedException {
+        // Arrange
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        Person person1 = new Person("Person1");
+        person1.setAge("1");
+        Person person2 = new Person("Person2");
+        person2.setAge("2");
+        Person person3 = new Person("Person3");
+        person3.setAge("3");
+        Person person4 = new Person("Person4");
+        person4.setAge("4");
+
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person1);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person3);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person4);
+        assertNotNull(saveCallback.getResult());
+
+        int allItemsBefore = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        assertTrue(allItemsBefore == 4);
+
+        // Act
+        Query query = new Query().equals("username", "Person2");
+        int deletedPersonCount = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).delete(query);
+        int allItemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        List<Person> itemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get();
+
+        // Assert
+        assertTrue(deletedPersonCount == 1);
+        assertTrue(allItemsAfter == 3);
+        assertNotNull(itemsAfter);
+        String username1 = itemsAfter.get(0).getUsername();
+        String username2 = itemsAfter.get(1).getUsername();
+        String username3 = itemsAfter.get(2).getUsername();
+        assertTrue(username1.equalsIgnoreCase("Person1") || username1.equalsIgnoreCase("Person3") || username1.equalsIgnoreCase("Person4"));
+        assertTrue(username2.equalsIgnoreCase("Person1") || username2.equalsIgnoreCase("Person3") || username2.equalsIgnoreCase("Person4"));
+        assertTrue(username3.equalsIgnoreCase("Person1") || username3.equalsIgnoreCase("Person3") || username3.equalsIgnoreCase("Person4"));
+    }
+
+    @Test
+    public void testDeleteMethodSkip1() throws InterruptedException {
+        // Arrange
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        Person person1 = new Person("Person1");
+        person1.setAge("1");
+        Person person2 = new Person("Person2");
+        person2.setAge("2");
+        Person person3 = new Person("Person3");
+        person3.setAge("3");
+        Person person4 = new Person("Person4");
+        person4.setAge("4");
+
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person1);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person3);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person4);
+        assertNotNull(saveCallback.getResult());
+
+        int allItemsBefore = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        assertTrue(allItemsBefore == 4);
+
+        // Act
+        Query query = new Query().setSkip(1);
+        int deletedPersonCount = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).delete(query);
+        int allItemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        List<Person> itemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get();
+
+        // Assert
+        assertTrue(deletedPersonCount == 3);
+        assertTrue(allItemsAfter == 1);
+        assertNotNull(itemsAfter);
+    }
+
+    @Test
+    public void testDeleteMethodSkip1Limit2() throws InterruptedException {
+        // Arrange
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        Person person1 = new Person("Person1");
+        person1.setAge("1");
+        Person person2 = new Person("Person2");
+        person2.setAge("2");
+        Person person3 = new Person("Person3");
+        person3.setAge("3");
+        Person person4 = new Person("Person4");
+        person4.setAge("4");
+
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person1);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person3);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person4);
+        assertNotNull(saveCallback.getResult());
+
+        int allItemsBefore = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        assertTrue(allItemsBefore == 4);
+
+        // Act
+        Query query = new Query().setSkip(1).setLimit(2);
+        int deletedPersonCount = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).delete(query);
+        int allItemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        List<Person> itemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get();
+
+        // Assert
+        assertTrue(deletedPersonCount == 2);
+        assertTrue(allItemsAfter == 2);
+        assertNotNull(itemsAfter);
+    }
+
+    @Test
+    public void testDeleteMethodSkip1LimitExceedsSize() throws InterruptedException {
+        // Arrange
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        Person person1 = new Person("Person1");
+        person1.setAge("1");
+        Person person2 = new Person("Person2");
+        person2.setAge("2");
+        Person person3 = new Person("Person3");
+        person3.setAge("3");
+        Person person4 = new Person("Person4");
+        person4.setAge("4");
+
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person1);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person3);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person4);
+        assertNotNull(saveCallback.getResult());
+
+        int allItemsBefore = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        assertTrue(allItemsBefore == 4);
+
+        // Act
+        Query query = new Query().setSkip(1).setLimit(5);
+        int deletedPersonCount = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).delete(query);
+        int allItemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        List<Person> itemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get();
+
+        // Assert
+        assertTrue(deletedPersonCount == 3);
+        assertTrue(allItemsAfter == 1);
+        assertNotNull(itemsAfter);
+    }
+
+    @Test
+    public void testDeleteMethodSkipExceedsSize() throws InterruptedException {
+        // Arrange
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        Person person1 = new Person("Person1");
+        person1.setAge("1");
+        Person person2 = new Person("Person2");
+        person2.setAge("2");
+        Person person3 = new Person("Person3");
+        person3.setAge("3");
+        Person person4 = new Person("Person4");
+        person4.setAge("4");
+
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person1);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person3);
+        assertNotNull(saveCallback.getResult());
+
+        saveCallback = null;
+        saveCallback = testManager.save(store, person4);
+        assertNotNull(saveCallback.getResult());
+
+        int allItemsBefore = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        assertTrue(allItemsBefore == 4);
+
+        // Act
+        Query query = new Query().setSkip(4);
+        int deletedPersonCount = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).delete(query);
+        int allItemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get().size();
+        List<Person> itemsAfter = client.getCacheManager().getCache(Person.COLLECTION, Person.class, Long.MAX_VALUE).get();
+
+        // Assert
+        assertTrue(deletedPersonCount == 0);
+        assertTrue(allItemsAfter == 4);
+        assertNotNull(itemsAfter);
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -599,7 +599,7 @@ public class DataStoreTest {
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
-                store.findCount(callback);
+                store.count(callback);
             }
         });
         looperThread.start();

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -13,6 +13,7 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.json.GenericJson;
 import com.kinvey.android.Client;
+import com.kinvey.android.callback.KinveyCountCallback;
 import com.kinvey.android.callback.KinveyDeleteCallback;
 import com.kinvey.android.callback.KinveyListCallback;
 import com.kinvey.android.callback.KinveyPurgeCallback;
@@ -35,6 +36,7 @@ import com.kinvey.java.store.StoreType;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -268,6 +270,28 @@ public class DataStoreTest {
         void finish() {
             latch.countDown();
         }
+    }
+
+    private static class DefaultKinveyCountCallback implements KinveyCountCallback {
+        private CountDownLatch latch;
+        Integer result;
+        Throwable error;
+
+        DefaultKinveyCountCallback(CountDownLatch latch) { this.latch = latch; }
+
+        @Override
+        public void onSuccess(Integer result) {
+            this.result = result;
+            finish();
+        }
+
+        @Override
+        public void onFailure(Throwable error) {
+            this.error = error;
+            finish();
+        }
+
+        void finish() { latch.countDown(); }
     }
 
     private static class DefaultKinveyDeleteCallback implements KinveyDeleteCallback {
@@ -533,6 +557,54 @@ public class DataStoreTest {
         assertNull(kinveyListCallback.error);
         assertNotNull(kinveyListCallback.result);
         assertTrue(kinveyListCallback.result.size() > 0);
+    }
+
+    @Test
+    @Ignore
+    public void testFindCountSync() throws InterruptedException, IOException {
+        testFindCount(StoreType.SYNC);
+    }
+
+    @Test
+    @Ignore
+    public void testFindCountCache() throws InterruptedException, IOException {
+        testFindCount(StoreType.CACHE);
+    }
+
+    @Test
+    public void testFindCountNetwork() throws InterruptedException, IOException {
+        testFindCount(StoreType.NETWORK);
+    }
+
+    private void testFindCount(StoreType storeType) throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, storeType, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+        Person person = createPerson(TEST_USERNAME);
+        DefaultKinveyClientCallback saveCallback = save(store, person);
+        assertNotNull(saveCallback.result);
+        assertNull(saveCallback.error);
+        assertNotNull(saveCallback.result.getId());
+
+        DefaultKinveyCountCallback countCallback = findCount(store, DEFAULT_TIMEOUT);
+        assertNull(countCallback.error);
+        assertNotNull(countCallback.result);
+        assertTrue(countCallback.result == 1);
+
+    }
+
+    private DefaultKinveyCountCallback findCount(final DataStore<Person> store, int seconds) throws InterruptedException, IOException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final DefaultKinveyCountCallback callback = new DefaultKinveyCountCallback(latch);
+        LooperThread looperThread = new LooperThread(new Runnable() {
+            @Override
+            public void run() {
+                store.findCount(callback);
+            }
+        });
+        looperThread.start();
+        latch.await(seconds, TimeUnit.SECONDS);
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
     }
 
     private DefaultKinveyDeleteCallback delete(final DataStore<Person> store, final String id, int seconds) throws InterruptedException {
@@ -1067,6 +1139,38 @@ public class DataStoreTest {
         DefaultKinveyPullCallback pullCallback = pull(store, null);
         assertNull(pullCallback.result);
         assertNotNull(pullCallback.error);
+    }
+
+    @Test
+    public void testPagedPull() throws InterruptedException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.CACHE, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+
+        cleanBackendDataStore(store);
+
+        // Arrange
+        ArrayList<Person> persons = new ArrayList<>();
+        Person curly = createPerson("Curly");
+        Person larry = createPerson("Larry");
+        Person moe = createPerson("Moe");
+        save(store, curly);
+        save(store, larry);
+        save(store, moe);
+        long cacheSizeBefore = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBefore == 3);
+        client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
+        long cacheSizeBetween = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBetween == 0);
+
+        // Act
+        store.setAutoPagination(true);
+        DefaultKinveyPullCallback pullCallback = pull(store, null);
+
+        // Assert
+        assertNull(pullCallback.error);
+        assertNotNull(pullCallback.result);
+        assertTrue(pullCallback.result.getResult().size() == 3);
+        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.CACHE));
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -560,13 +560,11 @@ public class DataStoreTest {
     }
 
     @Test
-    @Ignore
     public void testFindCountSync() throws InterruptedException, IOException {
         testFindCount(StoreType.SYNC);
     }
 
     @Test
-    @Ignore
     public void testFindCountCache() throws InterruptedException, IOException {
         testFindCount(StoreType.CACHE);
     }
@@ -578,7 +576,11 @@ public class DataStoreTest {
 
     private void testFindCount(StoreType storeType) throws InterruptedException, IOException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, storeType, client);
-        client.getSyncManager().clear(Person.COLLECTION);
+        if (storeType != StoreType.NETWORK) {
+            client.getSyncManager().clear(Person.COLLECTION);
+        }
+
+        clearBackend(store);
         Person person = createPerson(TEST_USERNAME);
         DefaultKinveyClientCallback saveCallback = save(store, person);
         assertNotNull(saveCallback.result);
@@ -589,7 +591,6 @@ public class DataStoreTest {
         assertNull(countCallback.error);
         assertNotNull(countCallback.result);
         assertTrue(countCallback.result == 1);
-
     }
 
     private DefaultKinveyCountCallback findCount(final DataStore<Person> store, int seconds) throws InterruptedException, IOException {
@@ -998,6 +999,12 @@ public class DataStoreTest {
         assertNull(pushCallback.error);
         assertTrue(pushCallback.result.getListOfExceptions().size() == 0);
         Log.d("testPull", " : clearing backend store successful");
+    }
+
+    private void clearBackend(DataStore<Person> store) throws InterruptedException {
+        Query query = client.query();
+        query = query.notEqual("age", "100500");
+        DefaultKinveyDeleteCallback deleteCallback = delete(store, query);
     }
 
     //use for Person.COLLECTION and for Person.class

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
@@ -16,10 +16,15 @@
 
 package com.kinvey.android;
 
+import com.google.api.client.json.GenericJson;
+
 import com.kinvey.android.sync.KinveyPullCallback;
 import com.kinvey.android.sync.KinveyPullResponse;
 import com.kinvey.java.Query;
+import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.BaseDataStore;
+import com.kinvey.java.store.ReadPolicy;
+import com.kinvey.java.store.requests.data.read.ReadCountRequest;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -57,7 +62,11 @@ public class AsyncPagedPullRequest<T> extends AsyncClientRequest<KinveyPullRespo
         int pageSize = 10000;
 
         // First, get the count of all the items to pull
-        int totalItemCount = 0; // TODO implement _count call to KCS
+        int totalItemCount = store.findCountNetwork();
+
+        if (query == null) {
+            query = new Query();
+        }
 
         List<T> totalPullResults = new ArrayList<>();
         do {

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
@@ -62,7 +62,7 @@ public class AsyncPagedPullRequest<T> extends AsyncClientRequest<KinveyPullRespo
         int pageSize = 10000;
 
         // First, get the count of all the items to pull
-        int totalItemCount = store.findCountNetwork();
+        int totalItemCount = store.countNetwork();
 
         if (query == null) {
             query = new Query();

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPagedPullRequest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+
+package com.kinvey.android;
+
+import com.kinvey.android.sync.KinveyPullCallback;
+import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.Query;
+import com.kinvey.java.store.BaseDataStore;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class represents internal implementation of async paged pull request that is used to automate
+ * pull request pagination.
+ */
+public class AsyncPagedPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T>> {
+    private final BaseDataStore store;
+    private Query query;
+
+    /**
+     * Async pull request constructor
+     * @param query Query that is used to fetch data from network
+     * @param store Kinvey data store instance to be used to execute network requests
+     * @param callback async callbacks to be invoked when job is done
+     */
+    public AsyncPagedPullRequest(BaseDataStore store,
+                            Query query,
+                            KinveyPullCallback<T> callback){
+        super(callback);
+        this.query = query;
+        this.store = store;
+    }
+
+
+    @Override
+    protected KinveyPullResponse<T> executeAsync() throws IOException, InvocationTargetException, IllegalAccessException {
+        KinveyPullResponse<T> kinveyPullResponse = new KinveyPullResponse<T>();
+
+        int skipCount = 0;
+        int pageSize = 10000;
+
+        // First, get the count of all the items to pull
+        int totalItemCount = 0; // TODO implement _count call to KCS
+
+        List<T> totalPullResults = new ArrayList<>();
+        do {
+            query.setSkip(skipCount).setLimit(pageSize);
+            totalPullResults.addAll(store.pullBlocking(query));
+            skipCount += pageSize;
+        } while (skipCount < totalItemCount);
+
+        kinveyPullResponse.setResult(totalPullResults);
+
+        return kinveyPullResponse;
+    }
+}

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -298,7 +298,9 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                         ids.add((String)id.get("_id"));
                     }
                     mRealm.commitTransaction();
-                    this.delete(ids);
+                    if (ids.size() > 0) {
+                        this.delete(ids);
+                    }
                 } else if (skip > 0) {
                     // only skip modifier has been applied, so take a subset of the Realm result set
                     if (skip < result.size()) {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -456,19 +456,26 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return ret;
     }
 
+
     @Override
     public long count(Query q) {
         DynamicRealm mRealm = mCacheManager.getDynamicRealm();
         long ret = 0;
         try {
-            if (!isQueryContainsInOperator(q.getQueryFilterMap())) {
+            if (q != null && !isQueryContainsInOperator(q.getQueryFilterMap())) {
                 mRealm.beginTransaction();
                 RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection);
                 QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
                 ret = query.count();
                 mRealm.commitTransaction();
             } else {
-                List<T> list = get(q);
+                List<T> list;
+                if (q != null) {
+                    list = get(q);
+                }
+                else {
+                    list = get();
+                }
                 ret = list.size();
             }
         } finally {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -282,9 +282,44 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap());
 
                 RealmResults result = realmQuery.findAll();
+
                 ret = result.size();
-                result.deleteAllFromRealm();
-                mRealm.commitTransaction();
+                int limit = query.getLimit();
+                int skip = query.getSkip();
+
+                if (limit > 0)
+                {
+                    // limit modifier has been applied, so take a subset of the Realm result set
+                    int endIndex = Math.min(ret, (skip+limit));
+                    List<DynamicRealmObject> subresult = result.subList(skip, endIndex);
+                    List<String> ids = new ArrayList<String>();
+                    ret = subresult.size();
+                    for (DynamicRealmObject id : subresult) {
+                        ids.add((String)id.get("_id"));
+                    }
+                    mRealm.commitTransaction();
+                    this.delete(ids);
+                } else if (skip > 0) {
+                    // only skip modifier has been applied, so take a subset of the Realm result set
+                    if (skip < result.size()) {
+                        List<DynamicRealmObject> subresult = result.subList(skip, result.size());
+                        List<String> ids = new ArrayList<String>();
+                        ret = subresult.size();
+                        for (DynamicRealmObject id : subresult) {
+                            ids.add((String) id.get("_id"));
+                        }
+                        mRealm.commitTransaction();
+                        this.delete(ids);
+                    }
+                    else {
+                        ret = 0;
+                    }
+                } else {
+                    // no skip or limit applied to query, so delete all results from Realm
+                    result.deleteAllFromRealm();
+                    mRealm.commitTransaction();
+                }
+
             } else {
                 List<T> list = get(query);
                 ret = list.size();

--- a/android-lib/src/main/java/com/kinvey/android/callback/KinveyCountCallback.java
+++ b/android-lib/src/main/java/com/kinvey/android/callback/KinveyCountCallback.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+package com.kinvey.android.callback;
+
+import com.kinvey.java.core.KinveyClientCallback;
+
+public interface KinveyCountCallback extends KinveyClientCallback<Integer> {
+
+    /**
+     * Used to indicate successful execution of a request by the background service.
+     *
+     * @param result count of the number of entities in the collection
+     */
+    void onSuccess(Integer result);
+
+    /**
+     * Used to indicate the failed execution of a request by the background service.
+     *
+     * @param error error
+     */
+    void onFailure(Throwable error);
+}

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -179,7 +179,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
             tempMap.put(KEY_GET_ALL, BaseDataStore.class.getMethod("find", KinveyCachedClientCallback.class));
             tempMap.put(KEY_GET_BY_IDS, BaseDataStore.class.getMethod("find", Iterable.class, KinveyCachedClientCallback.class));
 
-            tempMap.put(KEY_GET_COUNT, BaseDataStore.class.getMethod("findCount"));
+            tempMap.put(KEY_GET_COUNT, BaseDataStore.class.getMethod("count"));
 
             tempMap.put(KEY_DELETE_BY_ID, BaseDataStore.class.getMethod("delete", String.class));
             tempMap.put(KEY_DELETE_BY_QUERY, BaseDataStore.class.getMethod("delete", Query.class));
@@ -447,7 +447,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
         new AsyncRequest<List<T>>(this, methodMap.get(KEY_GET_ALL), callback, getWrappedCacheCallback(cachedCallback)).execute();
     }
 
-    public void findCount(KinveyCountCallback callback) {
+    public void count(KinveyCountCallback callback) {
         new AsyncRequest<Integer>(this, methodMap.get(KEY_GET_COUNT), callback).execute();
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -20,6 +20,7 @@ import com.google.api.client.json.GenericJson;
 import com.google.common.base.Preconditions;
 import com.kinvey.android.AsyncClientRequest;
 import com.kinvey.android.AsyncPullRequest;
+import com.kinvey.android.AsyncPagedPullRequest;
 import com.kinvey.android.KinveyCallbackHandler;
 import com.kinvey.android.async.AsyncPushRequest;
 import com.kinvey.android.async.AsyncRequest;
@@ -644,7 +645,12 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     public void pull(Query query, KinveyPullCallback<T> callback) {
         Preconditions.checkNotNull(client, "client must not be null");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
-        new AsyncPullRequest<T>(this, query, callback).execute();
+
+        if (isAutoPaginationEnabled()) {
+            new AsyncPagedPullRequest<T>(this, query, callback).execute();
+        } else {
+            new AsyncPullRequest<T>(this, query, callback).execute();
+        }
     }
 
     /**

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -24,6 +24,7 @@ import com.kinvey.android.AsyncPagedPullRequest;
 import com.kinvey.android.KinveyCallbackHandler;
 import com.kinvey.android.async.AsyncPushRequest;
 import com.kinvey.android.async.AsyncRequest;
+import com.kinvey.android.callback.KinveyCountCallback;
 import com.kinvey.android.callback.KinveyDeleteCallback;
 import com.kinvey.android.callback.KinveyListCallback;
 import com.kinvey.android.callback.KinveyPurgeCallback;
@@ -111,6 +112,8 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     private static final String KEY_GET_ALL = "KEY_GET_ALL";
     private static final String KEY_GET_BY_IDS = "KEY_GET_BY_IDS";
 
+    private static final String KEY_GET_COUNT = "KEY_GET_COUNT";
+
     private static final String KEY_DELETE_BY_ID = "KEY_DELETE_BY_ID";
     private static final String KEY_DELETE_BY_QUERY = "KEY_DELETE_BY_QUERY";
     private static final String KEY_DELETE_BY_IDS = "KEY_DELETE_BY_IDS";
@@ -175,6 +178,8 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
             tempMap.put(KEY_GET_BY_QUERY, BaseDataStore.class.getMethod("find", Query.class, KinveyCachedClientCallback.class));
             tempMap.put(KEY_GET_ALL, BaseDataStore.class.getMethod("find", KinveyCachedClientCallback.class));
             tempMap.put(KEY_GET_BY_IDS, BaseDataStore.class.getMethod("find", Iterable.class, KinveyCachedClientCallback.class));
+
+            tempMap.put(KEY_GET_COUNT, BaseDataStore.class.getMethod("findCount"));
 
             tempMap.put(KEY_DELETE_BY_ID, BaseDataStore.class.getMethod("delete", String.class));
             tempMap.put(KEY_DELETE_BY_QUERY, BaseDataStore.class.getMethod("delete", Query.class));
@@ -411,7 +416,6 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
         find(callback, null);
     }
 
-
     /**
      * Asynchronous request to fetch an list of all Entities in a collection.
      * <p>
@@ -443,6 +447,9 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
         new AsyncRequest<List<T>>(this, methodMap.get(KEY_GET_ALL), callback, getWrappedCacheCallback(cachedCallback)).execute();
     }
 
+    public void findCount(KinveyCountCallback callback) {
+        new AsyncRequest<Integer>(this, methodMap.get(KEY_GET_COUNT), callback).execute();
+    }
 
     /**
      * Asynchronous request to save or update an entity to a collection.
@@ -677,7 +684,11 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     public void pull(KinveyPullCallback<T> callback) {
         Preconditions.checkNotNull(client, "client must not be null");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
-        new AsyncPullRequest<T>(this, null, callback).execute();
+        if (isAutoPaginationEnabled()) {
+            new AsyncPagedPullRequest<T>(this, null, callback).execute();
+        } else {
+            new AsyncPullRequest<T>(this, null, callback).execute();
+        }
     }
 
     /**

--- a/java-api-core/src/com/kinvey/java/model/KinveyCountResponse.java
+++ b/java-api-core/src/com/kinvey/java/model/KinveyCountResponse.java
@@ -1,0 +1,19 @@
+package com.kinvey.java.model;
+
+import com.google.api.client.util.Key;
+
+public class KinveyCountResponse {
+    @Key
+    private int count;
+
+    /**
+     * @return The number of objects successfully deleted.
+     */
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count){
+        this.count = count;
+    }
+}

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -34,8 +34,10 @@ import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.deltaset.DeltaSetItem;
 import com.kinvey.java.deltaset.DeltaSetMerge;
 import com.kinvey.java.model.AggregateEntity;
+import com.kinvey.java.model.KinveyCountResponse;
 import com.kinvey.java.model.KinveyDeleteResponse;
 import com.kinvey.java.query.MongoQueryFilter;
+import com.kinvey.java.store.requests.data.read.ReadCountRequest;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -312,6 +314,13 @@ public class NetworkManager<T extends GenericJson> {
 
         client.initializeRequest(get);
         return get;
+    }
+
+    public GetCount getCountBlocking() throws IOException {
+//        Preconditions.checkNotNull();
+        GetCount getCount = new GetCount();
+        client.initializeRequest(getCount);
+        return getCount;
     }
 
     /**
@@ -744,6 +753,38 @@ public class NetworkManager<T extends GenericJson> {
             T myEntity = super.execute();
 
             return myEntity;
+        }
+    }
+
+    /**
+     * Generic Get class.  Constructs the HTTP request object for Get
+     * requests.
+     *
+     */
+    public class GetCount extends AbstractKinveyJsonClientRequest<KinveyCountResponse> {
+
+        private static final String REST_PATH = "appdata/{appKey}/{collectionName}/_count";
+
+        @Key
+        private String collectionName;
+
+//        GetCount(String queryString) {
+//            super(client, "GET", REST_PATH, null, myClass);
+//            this.collectionName= NetworkManager.this.collectionName;
+//            this.getRequestHeaders().put("X-Kinvey-Client-App-Version", NetworkManager.this.clientAppVersion);
+//            if (NetworkManager.this.customRequestProperties != null && !NetworkManager.this.customRequestProperties.isEmpty()){
+//                this.getRequestHeaders().put("X-Kinvey-Custom-Request-Properties", new Gson().toJson(NetworkManager.this.customRequestProperties) );
+//            }
+//        }
+
+        GetCount() {
+            super (client, "GET", REST_PATH, null, KinveyCountResponse.class);
+            this.collectionName= NetworkManager.this.collectionName;
+
+            this.getRequestHeaders().put("X-Kinvey-Client-App-Version", NetworkManager.this.clientAppVersion);
+            if (NetworkManager.this.customRequestProperties != null && !NetworkManager.this.customRequestProperties.isEmpty()){
+                this.getRequestHeaders().put("X-Kinvey-Custom-Request-Properties", new Gson().toJson(NetworkManager.this.customRequestProperties) );
+            }
         }
     }
 

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -57,6 +57,22 @@ public class BaseDataStore<T extends GenericJson> {
      */
     private boolean deltaSetCachingEnabled = false;
 
+    /**
+     * It is a parameter to enable the auto-pagination of data retrieval from the backend.
+     * When you use a Sync or Cache data store, if you have more than 10,000 entities, normally
+     * a developer would have to provide skip and limit modifiers to page through all the results.
+     * Setting this value to true will automatically fetch all the pages necessary.
+     * Default value is false.
+     */
+    private boolean autoPagination = false;
+
+    public boolean isAutoPaginationEnabled() {
+        return this.autoPagination;
+    }
+
+    public void setAutoPagination(boolean paginate) {
+        this.autoPagination = paginate;
+    }
 
     /**
      * Constructor for creating BaseDataStore for given collection that will be mapped to itemType class

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -225,13 +225,13 @@ public class BaseDataStore<T extends GenericJson> {
         return find((KinveyCachedClientCallback<List<T>>)null);
     }
 
-    public Integer findCount() throws IOException {
+    public Integer count() throws IOException {
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
         return new ReadCountRequest<T>(cache, networkManager, this.storeType.readPolicy, null, client.getSyncManager()).execute();
     }
 
-    public Integer findCountNetwork() throws IOException {
+    public Integer countNetwork() throws IOException {
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
         return new ReadCountRequest<T>(cache, networkManager, ReadPolicy.FORCE_NETWORK, null, client.getSyncManager()).execute();
@@ -331,9 +331,6 @@ public class BaseDataStore<T extends GenericJson> {
         return networkData;
     }
 
-    public void getCountBlocking() throws IOException {
-        networkManager.getCountBlocking();
-    }
     /**
      * Run sync operation to sync local and network storages
      * @param query query to pull the objects

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -27,6 +27,7 @@ import com.kinvey.java.store.requests.data.PushRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteIdsRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteQueryRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteSingleRequest;
+import com.kinvey.java.store.requests.data.read.ReadCountRequest;
 import com.kinvey.java.store.requests.data.read.ReadSingleRequest;
 import com.kinvey.java.store.requests.data.save.SaveListRequest;
 import com.kinvey.java.store.requests.data.save.SaveRequest;
@@ -224,6 +225,18 @@ public class BaseDataStore<T extends GenericJson> {
         return find((KinveyCachedClientCallback<List<T>>)null);
     }
 
+    public Integer findCount() throws IOException {
+        Preconditions.checkNotNull(client, "client must not be null.");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        return new ReadCountRequest<T>(cache, networkManager, this.storeType.readPolicy, null, client.getSyncManager()).execute();
+    }
+
+    public Integer findCountNetwork() throws IOException {
+        Preconditions.checkNotNull(client, "client must not be null.");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        return new ReadCountRequest<T>(cache, networkManager, ReadPolicy.FORCE_NETWORK, null, client.getSyncManager()).execute();
+    }
+
     /**
      * Save multiple objects for collections
      * @param objects list of objects to be saved
@@ -318,6 +331,9 @@ public class BaseDataStore<T extends GenericJson> {
         return networkData;
     }
 
+    public void getCountBlocking() throws IOException {
+        networkManager.getCountBlocking();
+    }
     /**
      * Run sync operation to sync local and network storages
      * @param query query to pull the objects

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/AbstractReadCountRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/AbstractReadCountRequest.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+
+package com.kinvey.java.store.requests.data.read;
+
+import com.google.api.client.json.GenericJson;
+import com.kinvey.java.cache.ICache;
+import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
+import com.kinvey.java.model.KinveyCountResponse;
+import com.kinvey.java.network.NetworkManager;
+import com.kinvey.java.store.ReadPolicy;
+import com.kinvey.java.store.WritePolicy;
+import com.kinvey.java.store.requests.data.IRequest;
+import com.kinvey.java.store.requests.data.PushRequest;
+import com.kinvey.java.sync.SyncManager;
+
+import java.io.IOException;
+
+public abstract class AbstractReadCountRequest<T extends GenericJson> implements IRequest<Integer> {
+    protected final ICache<T> cache;
+    private final ReadPolicy readPolicy;
+    protected NetworkManager<T> networkManager;
+    private SyncManager syncManager;
+
+    public AbstractReadCountRequest(ICache<T> cache, ReadPolicy readPolicy, NetworkManager<T> networkManager,
+                                 SyncManager syncManager) {
+
+        this.cache = cache;
+        this.readPolicy = readPolicy;
+        this.networkManager = networkManager;
+        this.syncManager = syncManager;
+    }
+
+    @Override
+    public Integer execute() throws IOException {
+        Integer ret = 0;
+        AbstractKinveyJsonClientRequest<KinveyCountResponse> request = null;
+        try {
+            request = countNetwork();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        switch (readPolicy){
+//            case FORCE_LOCAL:
+//                ret = countCached();
+//                syncManager.enqueueRequest(networkManager.getCollectionName(), request);
+//                break;
+//            case LOCAL_THEN_NETWORK:
+//                PushRequest<T> pushRequest = new PushRequest<T>(networkManager.getCollectionName(),
+//                        networkManager.getClient());
+//                try {
+//                    pushRequest.execute();
+//                } catch (Throwable t){
+//                    // silent fall, will be synced next time
+//                }
+//
+//                ret = countCached();
+//                try{
+//                    ret = request.execute().getCount();
+//                } catch (IOException e) {
+//                    syncManager.enqueueRequest(networkManager.getCollectionName(),
+//                            request);
+//                    throw e;
+//                }
+//                break;
+            case FORCE_NETWORK:
+                KinveyCountResponse response = request.execute();
+                ret = response.getCount();
+                break;
+        }
+        return ret;
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    abstract protected Integer countCached();
+
+    abstract protected AbstractKinveyJsonClientRequest<KinveyCountResponse> countNetwork() throws IOException;
+}

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/AbstractReadCountRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/AbstractReadCountRequest.java
@@ -55,31 +55,31 @@ public abstract class AbstractReadCountRequest<T extends GenericJson> implements
         }
 
         switch (readPolicy){
-//            case FORCE_LOCAL:
-//                ret = countCached();
-//                syncManager.enqueueRequest(networkManager.getCollectionName(), request);
-//                break;
-//            case LOCAL_THEN_NETWORK:
-//                PushRequest<T> pushRequest = new PushRequest<T>(networkManager.getCollectionName(),
-//                        networkManager.getClient());
-//                try {
-//                    pushRequest.execute();
-//                } catch (Throwable t){
-//                    // silent fall, will be synced next time
-//                }
-//
-//                ret = countCached();
-//                try{
-//                    ret = request.execute().getCount();
-//                } catch (IOException e) {
-//                    syncManager.enqueueRequest(networkManager.getCollectionName(),
-//                            request);
-//                    throw e;
-//                }
-//                break;
+            case FORCE_LOCAL:
+                ret = countCached();
+                syncManager.enqueueRequest(networkManager.getCollectionName(), request);
+                break;
             case FORCE_NETWORK:
                 KinveyCountResponse response = request.execute();
                 ret = response.getCount();
+                break;
+            case BOTH:
+                PushRequest<T> pushRequest = new PushRequest<T>(networkManager.getCollectionName(),
+                        networkManager.getClient());
+                try {
+                    pushRequest.execute();
+                } catch (Throwable t){
+                    // silent fall, will be synced next time
+                }
+
+                ret = countCached();
+                try{
+                    ret = request.execute().getCount();
+                } catch (IOException e) {
+                    syncManager.enqueueRequest(networkManager.getCollectionName(),
+                            request);
+                    throw e;
+                }
                 break;
         }
         return ret;

--- a/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadCountRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/read/ReadCountRequest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2016, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+
+package com.kinvey.java.store.requests.data.read;
+
+import com.google.api.client.json.GenericJson;
+import com.kinvey.java.Query;
+import com.kinvey.java.cache.ICache;
+import com.kinvey.java.network.NetworkManager;
+import com.kinvey.java.store.ReadPolicy;
+import com.kinvey.java.sync.SyncManager;
+
+import java.io.IOException;
+
+public class ReadCountRequest<T extends GenericJson> extends AbstractReadCountRequest<T> {
+
+    private final Query query;
+
+    public ReadCountRequest(ICache<T> cache, NetworkManager<T> networkManager, ReadPolicy readPolicy,
+                              Query query, SyncManager syncManager) {
+        super(cache, readPolicy, networkManager, syncManager);
+        this.query = query;
+    }
+
+    @Override
+    protected Integer countCached() {
+        return ((Long) cache.count(query)).intValue();
+    }
+
+    @Override
+    protected NetworkManager.GetCount countNetwork() throws IOException {
+        return networkManager.getCountBlocking(/*query*/);
+    }
+}


### PR DESCRIPTION
#### Description
Customer is running into issues trying to pull more than 10k records into the local cache, which has to do with issues surrounding pagination and deletion of the appropriate page in the local cache. All of the data was being deleted from the database during each page write. This change is to offer an auto-pagination option, so that the SDK handles pagination implicitly.

#### Changes
Providing a flag on the `DataStore` to enable auto-pagination.  If this flag is set to `true`, then pagination through all records of a collection will happen implicitly. This fix includes changes to add skip and limit support for cache deleting.

#### Tests
Instrumented tests added.
