### PR TITLE
Feature/mlibz 2079 query null fields

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -566,13 +566,91 @@ public class DataStoreTest {
 
     @Test
     public void testMongoQueryStringBuilder() {
+        // Arrange
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.NETWORK, client);
         Query myQuery = client.query();
+        String expectedMongoQuery;
+        String mongoQuery;
+
+        // Act
+        // Assert
+
+        // Test field string value
+        myQuery = client.query();
+        myQuery.equals("testString", "a test");
+        expectedMongoQuery = "{\"testString\":\"a test\"}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field boolean value
+        myQuery = client.query();
+        myQuery.equals("testbool", true);
+        expectedMongoQuery = "{\"testbool\":true}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field int value
+        myQuery = client.query();
+        myQuery.equals("testint", 33);
+        expectedMongoQuery = "{\"testint\":33}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field long value
+        myQuery = client.query();
+        myQuery.equals("testlong", 34L);
+        expectedMongoQuery = "{\"testlong\":34}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field double value
+        myQuery = client.query();
+        myQuery.equals("testdouble", 34.0);
+        expectedMongoQuery = "{\"testdouble\":34.0}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field float value
+        myQuery = client.query();
+        myQuery.equals("testfloat", 34.0f);
+        expectedMongoQuery = "{\"testfloat\":34.0}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test field null value
+        myQuery = client.query();
+        myQuery.equals("testnull", null);
+        expectedMongoQuery = "{\"testnull\":null}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // $and query with 2 string values
+        myQuery = client.query();
+        myQuery.equals("testStr1", "test 1").and(client.query().equals("testStr2", "test 2"));
+        expectedMongoQuery = "{\"$and\":[{\"testStr1\":\"test 1\"},{\"testStr2\":\"test 2\"}]}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // $and query with 2 boolean values
+        myQuery = client.query();
+        myQuery.equals("testBool1", true).and(client.query().equals("testBool2", false));
+        expectedMongoQuery = "{\"$and\":[{\"testBool1\":true},{\"testBool2\":false}]}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // $and query with 2 int values
+        myQuery = client.query();
+        myQuery.equals("testInt1", 33).and(client.query().equals("testInt2", 23));
+        expectedMongoQuery = "{\"$and\":[{\"testInt1\":33},{\"testInt2\":23}]}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // $and query with null value
+        myQuery = client.query();
         String hospitalCode = "H1";
         myQuery.equals("hospitalCode", hospitalCode).and(client.query().equals("archived", null));
-        AbstractMap<String, Object> filterMap = myQuery.getQueryFilterMap();
-        String expectedMongoQuery = "{\"$and\":[{\"hospitalCode\":\"H1\"},{\"archived\":null}]}";
-        String mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        expectedMongoQuery = "{\"$and\":[{\"hospitalCode\":\"H1\"},{\"archived\":null}]}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
         assertEquals(expectedMongoQuery, mongoQuery);
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -48,6 +48,7 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -561,6 +562,18 @@ public class DataStoreTest {
         assertNull(kinveyListCallback.error);
         assertNotNull(kinveyListCallback.result);
         assertTrue(kinveyListCallback.result.size() > 0);
+    }
+
+    @Test
+    public void testMongoQueryStringBuilder() {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.NETWORK, client);
+        Query myQuery = client.query();
+        String hospitalCode = "H1";
+        myQuery.equals("hospitalCode", hospitalCode).and(client.query().equals("archived", null));
+        AbstractMap<String, Object> filterMap = myQuery.getQueryFilterMap();
+        String expectedMongoQuery = "{\"$and\":[{\"hospitalCode\":\"H1\"},{\"archived\":null}]}";
+        String mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -652,6 +652,14 @@ public class DataStoreTest {
         expectedMongoQuery = "{\"$and\":[{\"hospitalCode\":\"H1\"},{\"archived\":null}]}";
         mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
         assertEquals(expectedMongoQuery, mongoQuery);
+
+        // $and query with null value and boolean
+        myQuery = client.query();
+        Boolean isHospital = false;
+        myQuery.equals("isHospital", isHospital).and(client.query().equals("archived", null));
+        expectedMongoQuery = "{\"$and\":[{\"isHospital\":false},{\"archived\":null}]}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -596,6 +596,13 @@ public class DataStoreTest {
         mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
         assertEquals(expectedMongoQuery, mongoQuery);
 
+        int ttl = 120;
+        myQuery = client.query();
+        myQuery.equals("ttl_in_seconds", ttl);
+        expectedMongoQuery = "{\"ttl_in_seconds\":120}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
         // Test field long value
         myQuery = client.query();
         myQuery.equals("testlong", 34L);
@@ -621,6 +628,55 @@ public class DataStoreTest {
         myQuery = client.query();
         myQuery.equals("testnull", null);
         expectedMongoQuery = "{\"testnull\":null}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $ne operator
+        myQuery = client.query();
+        myQuery.notEqual("age", "100500");
+        expectedMongoQuery = "{\"age\":{\"$ne\":\"100500\"}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - string
+        myQuery = client.query();
+        myQuery.in("testIn", new String[]{"1","2","3"});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[\"1\",\"2\",\"3\"]}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - bool
+        myQuery = client.query();
+        myQuery.in("testIn", new Boolean[]{true,false,true});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[true,false,true]}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - int
+        myQuery = client.query();
+        myQuery.in("testIn", new Integer[]{1,2,3});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[1,2,3]}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - long
+        myQuery = client.query();
+        myQuery.in("testIn", new Long[]{1L,2L,3L});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[1,2,3]}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - float
+        myQuery = client.query();
+        myQuery.in("testIn", new Float[]{1.0f,2.0f,3.0f});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[1.0,2.0,3.0]}}";
+        mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
+        assertEquals(expectedMongoQuery, mongoQuery);
+
+        // Test $in operator - double
+        myQuery = client.query();
+        myQuery.in("testIn", new Double[]{1.1,2.2,3.3});
+        expectedMongoQuery = "{\"testIn\":{\"$in\":[1.1,2.2,3.3]}}";
         mongoQuery = myQuery.getQueryFilterJson(client.getJsonFactory());
         assertEquals(expectedMongoQuery, mongoQuery);
 

--- a/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
+++ b/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
@@ -100,15 +100,14 @@ public abstract class AbstractQuery implements Serializable{
             JsonGenerator generator = factory.createJsonGenerator(writer);
             AbstractMap<String, Object> filterMap = getQueryFilterMap();
             buildQueryString(generator, filterMap);
-//            generator.serialize(getQueryFilterMap());
             generator.flush();
             jsonResult = writer.toString();
         } catch (Exception ex) {
-            // TODO add exception handling here instead of supporessing exception
+            // TODO add exception handling here instead of suppressing exception
             ex.getMessage();
         }
 
-        if (jsonResult.equals("{}")) {
+        if (jsonResult.equals("{}") || jsonResult.equals("")) {
             return null;
         }
 
@@ -133,44 +132,116 @@ public abstract class AbstractQuery implements Serializable{
                         generator.writeFieldName(entry.getKey());
                         generator.writeString((String)entry.getValue());
                         generator.writeEndObject();
+                    } else if (valueClass.equals(String[].class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeStartArray();
+                        String[] valueStr = (String[]) entry.getValue();
+                        for (String str : valueStr) {
+                            generator.writeString(str);
+                        }
+                        generator.writeEndArray();
+                        generator.writeEndObject();
                     } else if (valueClass.equals(Boolean.class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeBoolean((boolean) entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Boolean[].class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeStartArray();
+                        Boolean[] valueBool = (Boolean[]) entry.getValue();
+                        for (boolean bool : valueBool) {
+                            generator.writeBoolean(bool);
+                        }
+                        generator.writeEndArray();
                         generator.writeEndObject();
                     } else if (valueClass.equals(Integer.class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeNumber((int)entry.getValue());
                         generator.writeEndObject();
+                    } else if (valueClass.equals(Integer[].class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeStartArray();
+                        Integer[] valueInt = (Integer[]) entry.getValue();
+                        for (int integer : valueInt) {
+                            generator.writeNumber(integer);
+                        }
+                        generator.writeEndArray();
+                        generator.writeEndObject();
                     } else if (valueClass.equals(Long.class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeNumber((long)entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Long[].class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeStartArray();
+                        Long[] valueLong = (Long[]) entry.getValue();
+                        for (long longVal : valueLong) {
+                            generator.writeNumber(longVal);
+                        }
+                        generator.writeEndArray();
                         generator.writeEndObject();
                     } else if (valueClass.equals(Double.class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeNumber((double)entry.getValue());
                         generator.writeEndObject();
+                    } else if (valueClass.equals(Double[].class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeStartArray();
+                        Double[] valueDouble = (Double[]) entry.getValue();
+                        for (double doubleVal : valueDouble) {
+                            generator.writeNumber(doubleVal);
+                        }
+                        generator.writeEndArray();
+                        generator.writeEndObject();
                     } else if (valueClass.equals(Float.class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeNumber((float)entry.getValue());
                         generator.writeEndObject();
-                    } else if (valueClass.getComponentType() != null &&
-                            valueClass.getComponentType().equals(LinkedHashMap.class) &&
-                            valueClass.isArray()) {
-                        // Value is a map, so this is a nested query. Recursively call into it.
+                    } else if (valueClass.equals(Float[].class)) {
                         generator.writeStartObject();
                         generator.writeFieldName(entry.getKey());
                         generator.writeStartArray();
-                        LinkedHashMap[] valueMap = (LinkedHashMap<String, Object>[])entry.getValue();
-                        for (LinkedHashMap map : valueMap) {
-                            buildQueryString(generator, map);
+                        Float[] valueFloat = (Float[]) entry.getValue();
+                        for (float floatVal : valueFloat) {
+                            generator.writeNumber(floatVal);
                         }
                         generator.writeEndArray();
                         generator.writeEndObject();
+                    } else if (valueClass.equals(LinkedHashMap.class)) {
+                        // Value is an added filter
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        buildQueryString(generator, (LinkedHashMap) entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.getComponentType() != null &&
+                               valueClass.getComponentType().equals(LinkedHashMap.class)) {
+                        if (valueClass.isArray()) {
+                            // Value is a map, so this is a nested query. Recursively call into it.
+                            generator.writeStartObject();
+                            generator.writeFieldName(entry.getKey());
+                            generator.writeStartArray();
+                            LinkedHashMap[] valueMap = (LinkedHashMap<String, Object>[]) entry.getValue();
+                            for (LinkedHashMap map : valueMap) {
+                                buildQueryString(generator, map);
+                            }
+                            generator.writeEndArray();
+                            generator.writeEndObject();
+                        } else {
+                            // Value is an added filter
+                            generator.writeStartObject();
+                            buildQueryString(generator, (LinkedHashMap) entry.getValue());
+                            generator.writeEndObject();
+                        }
                     }
                 }
             }

--- a/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
+++ b/java-api-core/src/com/kinvey/java/query/AbstractQuery.java
@@ -133,7 +133,33 @@ public abstract class AbstractQuery implements Serializable{
                         generator.writeFieldName(entry.getKey());
                         generator.writeString((String)entry.getValue());
                         generator.writeEndObject();
-                    } else if (valueClass.getComponentType().equals(LinkedHashMap.class) &&
+                    } else if (valueClass.equals(Boolean.class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeBoolean((boolean) entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Integer.class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeNumber((int)entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Long.class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeNumber((long)entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Double.class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeNumber((double)entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.equals(Float.class)) {
+                        generator.writeStartObject();
+                        generator.writeFieldName(entry.getKey());
+                        generator.writeNumber((float)entry.getValue());
+                        generator.writeEndObject();
+                    } else if (valueClass.getComponentType() != null &&
+                            valueClass.getComponentType().equals(LinkedHashMap.class) &&
                             valueClass.isArray()) {
                         // Value is a map, so this is a nested query. Recursively call into it.
                         generator.writeStartObject();

--- a/java-api-core/test/com/kinvey/java/NetworkFileManagerTest.java
+++ b/java-api-core/test/com/kinvey/java/NetworkFileManagerTest.java
@@ -104,7 +104,7 @@ public class NetworkFileManagerTest extends KinveyMockUnitTest {
         NetworkFileManager.DownloadMetadataQuery download =
                 networkFileManagerApiUnderTest.prepDownloadWithTTLBlocking("testfilename.txt", 120);
         HttpRequest req = download.buildHttpRequest();
-        String expectedPath = HttpTesting.SIMPLE_URL + "/blob//testfilename.txt?query";
+        String expectedPath = HttpTesting.SIMPLE_URL + "/blob//testfilename.txt";
         assertEquals(expectedPath, req.getUrl().toString());
     }
 


### PR DESCRIPTION
#### Description
Creating a query in which a field is compared to `null` caused the query to produce an empty query against that field, yielding incorrect Mongo query string formation.

#### Changes
This was a result of using the `JsonGenerator.serialze()` method to create the Mongo query string. The [documentation for `JsonGenerator`](https://developers.google.com/api-client-library/java/google-http-java-client/reference/1.20.0/com/google/api/client/json/JsonGenerator) points out that if the value trying to be written is `null`, the object will not be serialized. To fix this, the use of `serialize()` was omitted in favor of using the lower-level methods to write values as JSON, such as `writeNull()`, `writeNumber()`, `writeString()`, etc.

#### Tests
Unit tests added to validate generated Mongo query strings.
