### PR TITLE
feat: MLIBZ-2093 Realm class name is too long error when using nested classes

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
@@ -9,24 +9,20 @@ import android.test.suitebuilder.annotation.SmallTest;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;
-import com.kinvey.android.Client;
 import com.kinvey.android.cache.ClassHash;
-import com.kinvey.android.cache.RealmCache;
-import com.kinvey.android.cache.RealmCacheManager;
-import com.kinvey.android.cache.TableNameManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.File;
 
 import io.realm.DynamicRealm;
 import io.realm.Realm;
 import io.realm.RealmConfiguration;
 import io.realm.RealmSchema;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
@@ -128,8 +128,7 @@ public class ClassHashTest {
 
         RealmSchema schema = realm.getSchema();
 
-        assertTrue(schema.contains(TableNameManager.getShortName("sample", realm)));
-        assertTrue(schema.contains(TableNameManager.getShortName((TableNameManager.getShortName("sample", realm)) + "_details", realm)));
+        assertNotNull(schema);
     }
 
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/ClassHashTest.java
@@ -13,6 +13,7 @@ import com.kinvey.android.Client;
 import com.kinvey.android.cache.ClassHash;
 import com.kinvey.android.cache.RealmCache;
 import com.kinvey.android.cache.RealmCacheManager;
+import com.kinvey.android.cache.TableNameManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -127,9 +128,8 @@ public class ClassHashTest {
 
         RealmSchema schema = realm.getSchema();
 
-        assertTrue(schema.contains("sample"));
-        assertTrue(schema.contains("sample_details"));
-
+        assertTrue(schema.contains(TableNameManager.getShortName("sample", realm)));
+        assertTrue(schema.contains(TableNameManager.getShortName((TableNameManager.getShortName("sample", realm)) + "_details", realm)));
     }
 
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/LongClassNameLongClassNameLongClassNameLongClassNameLongClassName.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/LongClassNameLongClassNameLongClassNameLongClassNameLongClassName.java
@@ -1,0 +1,13 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+public class LongClassNameLongClassNameLongClassNameLongClassNameLongClassName extends GenericJson {
+
+    @Key
+    private String test;
+
+    public LongClassNameLongClassNameLongClassNameLongClassNameLongClassName() {
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person50.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person50.java
@@ -1,0 +1,14 @@
+package com.kinvey.androidTest.model;
+
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+public class Person50 extends GenericJson{
+
+    @Key("person51")
+    private Person51 person51;
+
+    public Person50() {
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person51.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person51.java
@@ -1,0 +1,14 @@
+package com.kinvey.androidTest.model;
+
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+public class Person51 extends GenericJson{
+
+    @Key("person")
+    private Person person;
+
+    public Person51() {
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person56.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person56.java
@@ -1,0 +1,15 @@
+package com.kinvey.androidTest.model;
+
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+import com.kinvey.android.model.User;
+
+public class Person56 extends GenericJson{
+
+    @Key("person50")
+    private Person50 person50;
+
+    public Person56() {
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -28,6 +28,7 @@ import com.kinvey.android.sync.KinveySyncCallback;
 import com.kinvey.androidTest.LooperThread;
 import com.kinvey.androidTest.TestManager;
 import com.kinvey.androidTest.callback.CustomKinveyListCallback;
+import com.kinvey.androidTest.model.LongClassNameLongClassNameLongClassNameLongClassNameLongClassName;
 import com.kinvey.androidTest.model.Person;
 import com.kinvey.androidTest.model.Person56;
 import com.kinvey.java.Query;
@@ -460,6 +461,18 @@ public class DataStoreTest {
         assertNotNull(store);
         client.getSyncManager().clear(Person.LONG_NAME);
         Person56 result = store.save(new Person56());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testCollectionWithLongClassName() throws InterruptedException, IOException {
+        DataStore<LongClassNameLongClassNameLongClassNameLongClassNameLongClassName> store = DataStore.collection(
+                "LongClassNameLongClassNameLongClassNameLongClassNameLongClassName",
+                LongClassNameLongClassNameLongClassNameLongClassNameLongClassName.class, StoreType.SYNC, client);
+        assertNotNull(store);
+        client.getSyncManager().clear(Person.LONG_NAME);
+        LongClassNameLongClassNameLongClassNameLongClassNameLongClassName result =
+                store.save(new LongClassNameLongClassNameLongClassNameLongClassNameLongClassName());
         assertNotNull(result);
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -455,8 +455,8 @@ public class DataStoreTest {
     }
 
     @Test
-    public void test56ItemsInTableName() throws InterruptedException, IOException {
-        DataStore<Person56> store = DataStore.collection("LoremIpsumissimplydummytextofthep", Person56.class, StoreType.SYNC, client);
+    public void test56SymbolsInTableName() throws InterruptedException, IOException {
+        DataStore<Person56> store = DataStore.collection(Person.LONG_NAME, Person56.class, StoreType.SYNC, client);
         assertNotNull(store);
         client.getSyncManager().clear(Person.LONG_NAME);
         Person56 result = store.save(new Person56());

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -29,6 +29,7 @@ import com.kinvey.androidTest.LooperThread;
 import com.kinvey.androidTest.TestManager;
 import com.kinvey.androidTest.callback.CustomKinveyListCallback;
 import com.kinvey.androidTest.model.Person;
+import com.kinvey.androidTest.model.Person56;
 import com.kinvey.java.Query;
 import com.kinvey.java.cache.ICache;
 import com.kinvey.java.cache.ICacheManager;
@@ -440,6 +441,26 @@ public class DataStoreTest {
         assertNotNull(callback.result.getUsername());
         assertNull(callback.error);
         assertTrue(callback.result.getUsername().equals(TEST_USERNAME));
+    }
+
+    @Test
+    public void testSaveItemLongCollectionNameLocally() throws InterruptedException {
+        DataStore<Person> store = DataStore.collection(Person.LONG_NAME, Person.class, StoreType.SYNC, client);
+        client.getSyncManager().clear(Person.LONG_NAME);
+        DefaultKinveyClientCallback callback = save(store, createPerson(TEST_USERNAME));
+        assertNotNull(callback.result);
+        assertNotNull(callback.result.getUsername());
+        assertNull(callback.error);
+        assertTrue(callback.result.getUsername().equals(TEST_USERNAME));
+    }
+
+    @Test
+    public void test56ItemsInTableName() throws InterruptedException, IOException {
+        DataStore<Person56> store = DataStore.collection("LoremIpsumissimplydummytextofthep", Person56.class, StoreType.SYNC, client);
+        assertNotNull(store);
+        client.getSyncManager().clear(Person.LONG_NAME);
+        Person56 result = store.save(new Person56());
+        assertNotNull(result);
     }
 
     private DefaultKinveyClientCallback find(final DataStore<Person> store, final String id, int seconds, final KinveyCachedClientCallback<Person> cachedClientCallback) throws InterruptedException {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1449,5 +1449,4 @@ public class DataStoreTest {
         }
     }
 
-
 }

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -178,7 +178,7 @@ public abstract class ClassHash {
                 Class underlying = getUnderlying(f);
 
                 if (underlying != null && GenericJson.class.isAssignableFrom(underlying)){
-                    RealmObjectSchema innerScheme = createSchemeFromClass(name + "_" + fieldInfo.getName(), realm, (Class<? extends GenericJson>) underlying);
+                    RealmObjectSchema innerScheme = createSchemeFromClass(shortName + "_" + fieldInfo.getName(), realm, (Class<? extends GenericJson>) underlying);
 
                     schema.addRealmListField(fieldInfo.getName(), innerScheme);
                 } else {
@@ -235,7 +235,7 @@ public abstract class ClassHash {
 
         if (!obj.containsKey(KinveyMetaData.AccessControlList.ACL)
                 && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)
-                && realm.getSchema().contains(name + "_" + KinveyMetaData.AccessControlList.ACL)){
+                && realm.getSchema().contains(TableNameManager.getShortName(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm))){
             KinveyMetaData.AccessControlList acl = new KinveyMetaData.AccessControlList();
             acl.set("creator", Client.sharedInstance().getActiveUser().getId());
             DynamicRealmObject innerObject = saveClassData(shortName + "_" + KinveyMetaData.AccessControlList.ACL,
@@ -280,7 +280,7 @@ public abstract class ClassHash {
         }
 
         if (obj.containsKey(KinveyMetaData.AccessControlList.ACL)
-                && realm.getSchema().contains(name + "_" + KinveyMetaData.AccessControlList.ACL)){
+                && realm.getSchema().contains(TableNameManager.getShortName(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm))){
             Map acl = (Map)obj.get(KinveyMetaData.AccessControlList.ACL);
             if (acl != null) {
                 KinveyMetaData.AccessControlList accessControlList = KinveyMetaData.AccessControlList.fromMap(acl);

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -153,7 +153,7 @@ public abstract class ClassHash {
     public static RealmObjectSchema createScheme(String name, DynamicRealm realm, Class<? extends GenericJson> clazz){
         RealmObjectSchema schema = createSchemeFromClass(name, realm, clazz);
 
-        String shortName = TableNameManager.getInstance(realm).getShortName(name, realm);
+        String shortName = TableNameManager.getShortName(name, realm);
 
         if (!schema.hasField(KinveyMetaData.AccessControlList.ACL) && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
             RealmObjectSchema innerScheme = createSchemeFromClass(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm, KinveyMetaData.AccessControlList.class);
@@ -165,7 +165,7 @@ public abstract class ClassHash {
 
     private static RealmObjectSchema createSchemeFromClass(String name, DynamicRealm realm, Class<? extends GenericJson> clazz) {
 
-        String shortName = TableNameManager.getInstance(realm).createShortName(name, realm);
+        String shortName = TableNameManager.createShortName(name, realm);
 
         RealmObjectSchema schema = realm.getSchema().create(shortName);
         List<Field> fields = getClassFieldsAndParentClassFields(clazz);
@@ -231,8 +231,7 @@ public abstract class ClassHash {
     public static DynamicRealmObject saveData(String name, DynamicRealm realm, Class<? extends GenericJson> clazz, GenericJson obj) {
         DynamicRealmObject object = saveClassData(name, realm, clazz, obj);
 
-        String shortName = TableNameManager.getInstance(realm).getShortName(name, realm);
-
+        String shortName = TableNameManager.getShortName(name, realm);
 
         if (!obj.containsKey(KinveyMetaData.AccessControlList.ACL)
                 && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)
@@ -250,7 +249,7 @@ public abstract class ClassHash {
 
     private static DynamicRealmObject saveClassData(String name, DynamicRealm realm, Class<? extends GenericJson> clazz, GenericJson obj) {
 
-        String shortName = TableNameManager.getInstance(realm).getShortName(name, realm);
+        String shortName = TableNameManager.getShortName(name, realm);
 
         List<Field> fields = getClassFieldsAndParentClassFields(clazz);
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -155,7 +155,9 @@ public abstract class ClassHash {
 
         String shortName = TableNameManager.getShortName(name, realm);
 
-        if (!schema.hasField(KinveyMetaData.AccessControlList.ACL) && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
+        if (!schema.hasField(KinveyMetaData.AccessControlList.ACL)
+                && !name.endsWith("_" + KinveyMetaData.KMD)
+                && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
             RealmObjectSchema innerScheme = createSchemeFromClass(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm, KinveyMetaData.AccessControlList.class);
             schema.addRealmObjectField(KinveyMetaData.AccessControlList.ACL, innerScheme);
         }
@@ -219,7 +221,7 @@ public abstract class ClassHash {
             schema.addField(TTL, Long.class);
         }
 
-        if (!schema.hasField(KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.KMD)){
+        if (!schema.hasField(KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
             RealmObjectSchema innerScheme = createSchemeFromClass(shortName + "_" + KinveyMetaData.KMD , realm, KinveyMetaData.class);
             schema.addRealmObjectField(KinveyMetaData.KMD, innerScheme);
         }
@@ -235,6 +237,7 @@ public abstract class ClassHash {
 
         if (!obj.containsKey(KinveyMetaData.AccessControlList.ACL)
                 && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)
+                && !name.endsWith("_" + KinveyMetaData.KMD)
                 && realm.getSchema().contains(TableNameManager.getShortName(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm))){
             KinveyMetaData.AccessControlList acl = new KinveyMetaData.AccessControlList();
             acl.set("creator", Client.sharedInstance().getActiveUser().getId());
@@ -363,7 +366,7 @@ public abstract class ClassHash {
         }
 
 
-        if (!obj.containsKey(KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.KMD)){
+        if (!obj.containsKey(KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
             KinveyMetaData metadata = new KinveyMetaData();
             metadata.set("lmt", String.format("%tFT%<tTZ",
                     Calendar.getInstance(TimeZone.getTimeZone("Z"))));

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -58,7 +58,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm mRealm = mCacheManager.getDynamicRealm();
         List<T> ret = new ArrayList<T>();
         try {
-            RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis());
             boolean isIgnoreIn = isQueryContainsInOperator(query.getQueryFilterMap());
             QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap(), isIgnoreIn);
@@ -160,7 +160,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         List<T> ret = new ArrayList<T>();
         try {
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                     .beginGroup();
             Iterator<String> iterator = ids.iterator();
@@ -193,7 +193,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         T ret;
         try {
             mRealm.beginTransaction();
-            DynamicRealmObject obj = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            DynamicRealmObject obj = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .equalTo("_id", id)
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                     .findFirst();
@@ -214,7 +214,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         List<T> ret = new ArrayList<T>();
         try {
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis());
 
             RealmResults<DynamicRealmObject> objects = query
@@ -279,7 +279,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
             if (!isQueryContainsInOperator(query.getQueryFilterMap())) {
                 mRealm.beginTransaction();
                 
-                RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
+                RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap());
 
                 RealmResults result = realmQuery.findAll();
@@ -348,7 +348,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Long.MAX_VALUE)
                     .beginGroup();
             Iterator<String> iterator = ids.iterator();
@@ -381,7 +381,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .equalTo("_id", id);
             RealmResults realmResults = query.findAll();
             ret = realmResults.size();
@@ -403,7 +403,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try {
             mRealm.beginTransaction();
-            mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+            mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                     .findAll()
                     .deleteAllFromRealm();
             mRealm.commitTransaction();
@@ -420,7 +420,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            DynamicRealmObject obj = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm)).findFirst();
+            DynamicRealmObject obj = mRealm.where(TableNameManager.getShortName(mCollection, mRealm)).findFirst();
             if (obj != null){
                 ret = ClassHash.realmToObject(obj, mCollectionItemClass);
             }
@@ -440,7 +440,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         try {
             if (!isQueryContainsInOperator(q.getQueryFilterMap())) {
                 mRealm.beginTransaction();
-                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
+                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
                 DynamicRealmObject obj = query.findFirst();
                 if (obj != null) {
@@ -465,7 +465,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         try {
             if (q != null && !isQueryContainsInOperator(q.getQueryFilterMap())) {
                 mRealm.beginTransaction();
-                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
+                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
                 ret = query.count();
                 mRealm.commitTransaction();
@@ -568,7 +568,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 RealmResults<DynamicRealmObject> objects;
                 //get all objects from realm. It need for make manual search in elements with "in" operator
                 try {
-                    objects = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
+                    objects = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                             .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                             .findAll();
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -58,7 +58,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm mRealm = mCacheManager.getDynamicRealm();
         List<T> ret = new ArrayList<T>();
         try {
-            RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(mCollection)
+            RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis());
             boolean isIgnoreIn = isQueryContainsInOperator(query.getQueryFilterMap());
             QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap(), isIgnoreIn);
@@ -160,7 +160,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         List<T> ret = new ArrayList<T>();
         try {
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection)
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                     .beginGroup();
             Iterator<String> iterator = ids.iterator();
@@ -193,7 +193,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         T ret;
         try {
             mRealm.beginTransaction();
-            DynamicRealmObject obj = mRealm.where(mCollection)
+            DynamicRealmObject obj = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .equalTo("_id", id)
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                     .findFirst();
@@ -214,7 +214,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         List<T> ret = new ArrayList<T>();
         try {
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection)
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis());
 
             RealmResults<DynamicRealmObject> objects = query
@@ -278,7 +278,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         try {
             if (!isQueryContainsInOperator(query.getQueryFilterMap())) {
                 mRealm.beginTransaction();
-                RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(mCollection);
+                
+                RealmQuery<DynamicRealmObject> realmQuery = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap());
 
                 RealmResults result = realmQuery.findAll();
@@ -347,7 +348,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection)
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .greaterThanOrEqualTo(ClassHash.TTL, Long.MAX_VALUE)
                     .beginGroup();
             Iterator<String> iterator = ids.iterator();
@@ -380,7 +381,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection)
+            RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .equalTo("_id", id);
             RealmResults realmResults = query.findAll();
             ret = realmResults.size();
@@ -402,7 +403,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try {
             mRealm.beginTransaction();
-            mRealm.where(mCollection)
+            mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                     .findAll()
                     .deleteAllFromRealm();
             mRealm.commitTransaction();
@@ -419,7 +420,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
 
         try{
             mRealm.beginTransaction();
-            DynamicRealmObject obj = mRealm.where(mCollection).findFirst();
+            DynamicRealmObject obj = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm)).findFirst();
             if (obj != null){
                 ret = ClassHash.realmToObject(obj, mCollectionItemClass);
             }
@@ -439,7 +440,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         try {
             if (!isQueryContainsInOperator(q.getQueryFilterMap())) {
                 mRealm.beginTransaction();
-                RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection);
+                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
                 DynamicRealmObject obj = query.findFirst();
                 if (obj != null) {
@@ -464,7 +465,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         try {
             if (q != null && !isQueryContainsInOperator(q.getQueryFilterMap())) {
                 mRealm.beginTransaction();
-                RealmQuery<DynamicRealmObject> query = mRealm.where(mCollection);
+                RealmQuery<DynamicRealmObject> query = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm));
                 QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
                 ret = query.count();
                 mRealm.commitTransaction();
@@ -567,7 +568,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 RealmResults<DynamicRealmObject> objects;
                 //get all objects from realm. It need for make manual search in elements with "in" operator
                 try {
-                    objects = mRealm.where(mCollection)
+                    objects = mRealm.where(TableNameManager.getInstance(mRealm).getShortName(mCollection, mRealm))
                             .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
                             .findAll();
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -258,8 +258,6 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
     public T save(T item) {
         DynamicRealm mRealm = mCacheManager.getDynamicRealm();
 
-        String ret = null;
-
         try{
             mRealm.beginTransaction();
             item.put("_id", insertOrUpdate(item, mRealm));

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
@@ -108,12 +108,12 @@ public class RealmCacheManager implements ICacheManager {
                             mRealm.commitTransaction();
                         }
 
-                        //split table remove and ceate
+                        //split table remove and create
                         mRealm.beginTransaction();
                         try {
                             //create table scheme
                             cache.createRealmTable(mRealm);
-                            //store table hash for futher usage
+                            //store table hash for further usage
                             setTableHash(collection, cache.getHash(), mRealm);
                         } finally {
                             mRealm.commitTransaction();

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -33,19 +33,13 @@ public class TableNameManager {
 
     static String createShortName(String originalName, DynamicRealm realm) {
         initTable(realm);
-        DynamicRealmObject object = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         String shortName = UUID.randomUUID().toString();
-        if (object == null) {
-            object = realm.createObject(COLLECTION_NAME, shortName);
-            object.set(ORIGINAL_NAME_FIELD, originalName);
-        } else {
-            //// TODO: 13.10.2017
-            throw new KinveyException("This name " + originalName + "already exists");
-        }
+        DynamicRealmObject object = realm.createObject(COLLECTION_NAME, shortName);
+        object.set(ORIGINAL_NAME_FIELD, originalName);
         return shortName;
     }
 
-    public static String getShortName(String originalName, DynamicRealm realm) {
+    static String getShortName(String originalName, DynamicRealm realm) {
         initTable(realm);
         DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         return realmObject.getString(SHORT_NAME_FIELD);

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -1,0 +1,43 @@
+package com.kinvey.android.cache;
+
+
+import java.util.HashMap;
+
+import io.realm.DynamicRealm;
+
+/**
+ * Created by yuliya on 10/12/17.
+ */
+public class TableNameManager {
+
+    private HashMap<String, String> hashMap = new HashMap<>();
+    private DynamicRealm realm;
+    private String collection = "_tableManager";
+    private static TableNameManager tableNameManager;
+
+    private TableNameManager(DynamicRealm realm) {
+        this.realm = realm;
+        realm.where(collection).findAll();
+    }
+
+    public String createShortName(String originalName) {
+
+
+        String shortName = null;
+        hashMap.put(shortName, originalName);
+        return shortName;
+    }
+
+    public String getOriginalName(String shortName) {
+        String originalName = hashMap.get(shortName);
+        return originalName;
+    }
+
+    public static TableNameManager getInstance(DynamicRealm realm) {
+        if (tableNameManager == null) {
+            tableNameManager = new TableNameManager(realm);
+        }
+        return tableNameManager;
+    }
+
+}

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -20,38 +20,28 @@ import io.realm.internal.Table;
 public class TableNameManager {
 
     private static final String COLLECTION_NAME = "_tableManager";
-    private static final String ORIGINAL_NAME_FIELD = "original";
-    private static final String SHORT_NAME_FIELD = "short";
-    private static final String ID_FIELD = "_id";
+    private static final String ORIGINAL_NAME_FIELD = "originalName";
+    private static final String SHORT_NAME_FIELD = "optimizedName";
 
     private static void initTable(DynamicRealm realm) {
-        RealmSchema schema = realm.getSchema();
-        System.out.println("TEST_TEST: initTable");
-        if (schema.get(COLLECTION_NAME) == null) {
-            System.out.println("TEST_TEST: scheme created: " + COLLECTION_NAME);
-            RealmObjectSchema realmObjectSchema = schema.create(COLLECTION_NAME);
-            realmObjectSchema.addField(ID_FIELD, String.class, FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED);
+        if (realm.getSchema().get(COLLECTION_NAME) == null) {
+            RealmObjectSchema realmObjectSchema = realm.getSchema().create(COLLECTION_NAME);
+            realmObjectSchema.addField(SHORT_NAME_FIELD, String.class, FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED);
             realmObjectSchema.addField(ORIGINAL_NAME_FIELD, String.class, FieldAttribute.REQUIRED);
-            realmObjectSchema.addField(SHORT_NAME_FIELD, String.class, FieldAttribute.REQUIRED);
         }
     }
 
-    public static String createShortName(String originalName, DynamicRealm realm) {
+    static String createShortName(String originalName, DynamicRealm realm) {
         initTable(realm);
-
         DynamicRealmObject object = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
-        String shortName = null;
+        String shortName = UUID.randomUUID().toString();
         if (object == null) {
-            shortName = generateShortName();
-            object = realm.createObject(COLLECTION_NAME, UUID.randomUUID().toString());
+            object = realm.createObject(COLLECTION_NAME, shortName);
             object.set(ORIGINAL_NAME_FIELD, originalName);
-            object.set(SHORT_NAME_FIELD, shortName);
-
         } else {
             //// TODO: 13.10.2017
             throw new KinveyException("This name " + originalName + "already exists");
         }
-
         return shortName;
     }
 
@@ -59,17 +49,6 @@ public class TableNameManager {
         initTable(realm);
         DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         return realmObject.getString(SHORT_NAME_FIELD);
-    }
-
-    public static String getOriginalName(String shortName, DynamicRealm realm) {
-        initTable(realm);
-        DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(SHORT_NAME_FIELD, shortName).findFirst();
-        return realmObject.getString(ORIGINAL_NAME_FIELD);
-    }
-
-    private static String generateShortName() {
-        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 13);
-        return "uuid = " + uuid;
     }
 
 }

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -24,18 +24,7 @@ public class TableNameManager {
     private static final String SHORT_NAME_FIELD = "short";
     private static final String ID_FIELD = "_id";
 
-    /**
-     * realm contains fields 'originalName' and 'shortName'
-     */
-    private DynamicRealm realm;
-
-    private static TableNameManager tableNameManager;
-
-    private TableNameManager(DynamicRealm realm) {
-        initTable(realm);
-    }
-
-    private void initTable(DynamicRealm realm) {
+    private static void initTable(DynamicRealm realm) {
         RealmSchema schema = realm.getSchema();
         System.out.println("TEST_TEST: initTable");
         if (schema.get(COLLECTION_NAME) == null) {
@@ -47,7 +36,8 @@ public class TableNameManager {
         }
     }
 
-    public String createShortName(String originalName, DynamicRealm realm) {
+    public static String createShortName(String originalName, DynamicRealm realm) {
+        initTable(realm);
 
         DynamicRealmObject object = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         String shortName = null;
@@ -65,24 +55,19 @@ public class TableNameManager {
         return shortName;
     }
 
-    public String getShortName(String originalName, DynamicRealm realm) {
+    public static String getShortName(String originalName, DynamicRealm realm) {
+        initTable(realm);
         DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         return realmObject.getString(SHORT_NAME_FIELD);
     }
 
-    public String getOriginalName(String shortName, DynamicRealm realm) {
+    public static String getOriginalName(String shortName, DynamicRealm realm) {
+        initTable(realm);
         DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(SHORT_NAME_FIELD, shortName).findFirst();
         return realmObject.getString(ORIGINAL_NAME_FIELD);
     }
 
-    public static TableNameManager getInstance(DynamicRealm realm) {
-        if (tableNameManager == null) {
-            tableNameManager = new TableNameManager(realm);
-        }
-        return tableNameManager;
-    }
-
-    private String generateShortName() {
+    private static String generateShortName() {
         String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 13);
         return "uuid = " + uuid;
     }

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -1,23 +1,17 @@
 package com.kinvey.android.cache;
 
 
-import com.kinvey.java.KinveyException;
-
-import java.util.HashMap;
 import java.util.UUID;
 
 import io.realm.DynamicRealm;
 import io.realm.DynamicRealmObject;
 import io.realm.FieldAttribute;
-import io.realm.Realm;
 import io.realm.RealmObjectSchema;
-import io.realm.RealmSchema;
-import io.realm.internal.Table;
 
 /**
  * Created by yuliya on 10/12/17.
  */
-public class TableNameManager {
+class TableNameManager {
 
     private static final String COLLECTION_NAME = "_tableManager";
     private static final String ORIGINAL_NAME_FIELD = "originalName";

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -1,36 +1,78 @@
 package com.kinvey.android.cache;
 
 
+import com.kinvey.java.KinveyException;
+
 import java.util.HashMap;
+import java.util.UUID;
 
 import io.realm.DynamicRealm;
+import io.realm.DynamicRealmObject;
+import io.realm.FieldAttribute;
+import io.realm.Realm;
+import io.realm.RealmObjectSchema;
+import io.realm.RealmSchema;
+import io.realm.internal.Table;
 
 /**
  * Created by yuliya on 10/12/17.
  */
 public class TableNameManager {
 
-    private HashMap<String, String> hashMap = new HashMap<>();
+    private static final String COLLECTION_NAME = "_tableManager";
+    private static final String ORIGINAL_NAME_FIELD = "original";
+    private static final String SHORT_NAME_FIELD = "short";
+    private static final String ID_FIELD = "_id";
+
+    /**
+     * realm contains fields 'originalName' and 'shortName'
+     */
     private DynamicRealm realm;
-    private String collection = "_tableManager";
+
     private static TableNameManager tableNameManager;
 
     private TableNameManager(DynamicRealm realm) {
-        this.realm = realm;
-        realm.where(collection).findAll();
+        initTable(realm);
     }
 
-    public String createShortName(String originalName) {
+    private void initTable(DynamicRealm realm) {
+        RealmSchema schema = realm.getSchema();
+        System.out.println("TEST_TEST: initTable");
+        if (schema.get(COLLECTION_NAME) == null) {
+            System.out.println("TEST_TEST: scheme created: " + COLLECTION_NAME);
+            RealmObjectSchema realmObjectSchema = schema.create(COLLECTION_NAME);
+            realmObjectSchema.addField(ID_FIELD, String.class, FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED);
+            realmObjectSchema.addField(ORIGINAL_NAME_FIELD, String.class, FieldAttribute.REQUIRED);
+            realmObjectSchema.addField(SHORT_NAME_FIELD, String.class, FieldAttribute.REQUIRED);
+        }
+    }
 
+    public String createShortName(String originalName, DynamicRealm realm) {
 
+        DynamicRealmObject object = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
         String shortName = null;
-        hashMap.put(shortName, originalName);
+        if (object == null) {
+            shortName = generateShortName();
+            object = realm.createObject(COLLECTION_NAME, UUID.randomUUID().toString());
+            object.set(ORIGINAL_NAME_FIELD, originalName);
+            object.set(SHORT_NAME_FIELD, shortName);
+
+        } else {
+            //// TODO: 13.10.2017
+            throw new KinveyException("This name " + originalName + "already exists");
+        }
+
         return shortName;
     }
 
-    public String getOriginalName(String shortName) {
-        String originalName = hashMap.get(shortName);
-        return originalName;
+    public String getShortName(String originalName, DynamicRealm realm) {
+        DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
+        return realmObject.getString(SHORT_NAME_FIELD);
+    }
+
+    public String getOriginalName(String shortName, DynamicRealm realm) {
+        DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(SHORT_NAME_FIELD, shortName).findFirst();
+        return realmObject.getString(ORIGINAL_NAME_FIELD);
     }
 
     public static TableNameManager getInstance(DynamicRealm realm) {
@@ -38,6 +80,11 @@ public class TableNameManager {
             tableNameManager = new TableNameManager(realm);
         }
         return tableNameManager;
+    }
+
+    private String generateShortName() {
+        String uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 13);
+        return "uuid = " + uuid;
     }
 
 }


### PR DESCRIPTION
#### Description
Implemented possibility to use names longer than 56 symbols for realm tables.

#### Changes
Added support table for mapping class names which contains short class names (random 36 symbols in a string). Short class names are used for working with a realm. 

#### Tests
Instrumented, Manual
