### PR TITLE
fix: MLIBZ-2151 Android sdk 3.0.8 push() is throwing an exception

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1108,6 +1108,23 @@ public class DataStoreTest {
     }
 
     @Test
+    public void testSyncBlocking() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        cleanBackendDataStore(store);
+        client.getSyncManager().clear(Person.COLLECTION);
+        Person person = createPerson(TEST_USERNAME);
+        save(store, person);
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 1);
+        store.pushBlocking();
+        person = createPerson(TEST_USERNAME_2);
+        save(store, person);
+        store.syncBlocking(new Query());
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+        DefaultKinveyCountCallback countCallback = findCount(store, DEFAULT_TIMEOUT);
+        assertTrue(countCallback.result == 2);
+    }
+
+    @Test
     public void testPushInvalidDataStoreType() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.NETWORK, client);
         client.getSyncManager().clear(Person.COLLECTION);

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1097,6 +1097,17 @@ public class DataStoreTest {
     }
 
     @Test
+    public void testPushBlocking() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+        Person person = createPerson(TEST_USERNAME);
+        save(store, person);
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 1);
+        store.pushBlocking();
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+    }
+
+    @Test
     public void testPushInvalidDataStoreType() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.NETWORK, client);
         client.getSyncManager().clear(Person.COLLECTION);

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -34,14 +34,13 @@ import java.util.List;
  */
 public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteRequest<T> {
 
-    private final String collectionName;
     private ICache<T> cache;
     private NetworkManager<T> networkManager;
     private final SyncManager syncManager;
     private AbstractClient client;
 
     public PushRequest(String collectionName, ICache<T> cache, NetworkManager<T> networkManager, AbstractClient client){
-        this.collectionName = collectionName;
+        this.collection = collectionName;
         this.cache = cache;
         this.networkManager = networkManager;
         this.syncManager = client.getSyncManager();
@@ -55,7 +54,7 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
             syncManager.executeRequest(client, syncRequest);
         }
 
-        List<SyncItem> syncItems = syncManager.popSingleItemQueue(collectionName);
+        List<SyncItem> syncItems = syncManager.popSingleItemQueue(collection);
         SyncRequest syncRequest = null;
 
         if (syncItems != null) {


### PR DESCRIPTION
#### Description
Fixed BaseDataStore#pushblocking method

#### Changes
Collection name was saved not correctly. It was fixed.

#### Tests
Instrumented, manual.
