### PR TITLE
Feature/mlibz 2153 multiple sync requests sent per entity

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1125,6 +1125,29 @@ public class DataStoreTest {
     }
 
     @Test
+    public void testSyncBlocking2() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        cleanBackendDataStore(store);
+        client.getSyncManager().clear(Person.COLLECTION);
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+        Person person = createPerson(TEST_USERNAME);
+        save(store, person);
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 1);
+        person.setAge("237 y.o.");
+        save(store, person);
+        long countAfterSave = client.getSyncManager().getCount(Person.COLLECTION);
+        assertTrue(countAfterSave == 1);
+        person = createPerson(TEST_USERNAME_2);
+        save(store, person);
+        long countAfter2ndSave = client.getSyncManager().getCount(Person.COLLECTION);
+        assertTrue(countAfter2ndSave == 2);
+        store.syncBlocking(new Query());
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+        DefaultKinveyCountCallback countCallback = findCount(store, DEFAULT_TIMEOUT);
+        assertTrue(countCallback.result == 2);
+    }
+
+    @Test
     public void testPushInvalidDataStoreType() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.NETWORK, client);
         client.getSyncManager().clear(Person.COLLECTION);


### PR DESCRIPTION
#### Description
For each save to an entity in a `SYNC` store, an entry was being made into the `syncitems` table to capture the event for a `push`. But there should only be one entry in the `syncitems` table per entity, so that only the latest state of the entity gets pushed.

#### Changes
Check to see if an entry in the `syncitems` table already exists for this entity, and only add one if it does not.

#### Tests
Instrumented test added.
