### PR TITLE
feat: MLIBZ-2140  kmd grows exponentially every time a sync or pull is called(autopagination)

### DIFF
--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -51,9 +51,9 @@ import io.realm.RealmObjectSchema;
  */
 public abstract class ClassHash {
 
-    public static String TTL = "__ttl__";
-    private static String ID = "_id";
-    private static String ITEMS = "_items";
+    public static final String TTL = "__ttl__";
+    private static final String ID = "_id";
+    private static final String ITEMS = "_items";
 
     private static final HashSet<String> PRIVATE_FIELDS = new HashSet<String>(){
         {
@@ -266,14 +266,27 @@ public abstract class ClassHash {
             obj.put(ID, UUID.randomUUID().toString());
         }
 
+        String kmdId = null;
+        String aclId = null;
+
         if (object == null){
             object = realm.createObject(shortName, obj.get(ID));
+        } else {
+            if (object.hasField(KinveyMetaData.KMD)
+                    && object.getObject(KinveyMetaData.KMD) != null) {
+                kmdId = object.getObject(KinveyMetaData.KMD).getString(ID);
+            }
+            if (object.hasField(KinveyMetaData.AccessControlList.ACL)
+                    && object.getObject(KinveyMetaData.AccessControlList.ACL) != null) {
+                aclId = object.getObject(KinveyMetaData.AccessControlList.ACL).getString(ID);
+            }
         }
 
         if (obj.containsKey(KinveyMetaData.KMD)){
             Map kmd = (Map)obj.get(KinveyMetaData.KMD);
             if (kmd != null) {
                 KinveyMetaData metadata = KinveyMetaData.fromMap(kmd);
+                metadata.set(ID, kmdId);
                 DynamicRealmObject innerObject = saveClassData(shortName + "_" + KinveyMetaData.KMD,
                         realm,
                         KinveyMetaData.class,
@@ -287,6 +300,7 @@ public abstract class ClassHash {
             Map acl = (Map)obj.get(KinveyMetaData.AccessControlList.ACL);
             if (acl != null) {
                 KinveyMetaData.AccessControlList accessControlList = KinveyMetaData.AccessControlList.fromMap(acl);
+                accessControlList.set(ID, aclId);
                 DynamicRealmObject innerObject = saveClassData(shortName + "_" + KinveyMetaData.AccessControlList.ACL,
                         realm,
                         KinveyMetaData.AccessControlList.class,

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -281,8 +281,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         int i;
         try {
             List<T> items = get(query);
-            delete(realm, getACLIds(items), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getKMDIds(items), TableNameManager.getShortName(mCollection, realm) + KMD);
+            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, query, mCollection);
         } finally {
             realm.close();
@@ -290,20 +290,20 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return i;
     }
 
-    private List<String> getACLIds(List<T> items) {
-        List<String> ACLIds = new ArrayList<>();
+    /**
+     * Method gets item ids in support tables (_acl and _kmd)
+     * @param items items for getting them ids
+     * @param field _acl or _kmd
+     * @return item ids in support tables
+     */
+    private List<String> getSupportIds(List<T> items, String field) {
+        List<String> supportIds = new ArrayList<>();
         for (T item : items) {
-            ACLIds.add((String)((GenericJson) item.get("_acl")).get("_id"));
+            if (item.get(field) != null) {
+                supportIds.add((String) ((GenericJson) item.get(field)).get(ID));
+            }
         }
-        return ACLIds;
-    }
-
-    private List<String> getKMDIds(List<T> items) {
-        List<String> ACLIds = new ArrayList<>();
-        for (T item : items) {
-            ACLIds.add((String)((GenericJson) item.get("_kmd")).get("_id"));
-        }
-        return ACLIds;
+        return supportIds;
     }
 
     private int delete(DynamicRealm realm, Query query, String tableName) {
@@ -374,31 +374,13 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
-            delete(realm, getACLIds(ids), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getKMDIds(ids), TableNameManager.getShortName(mCollection, realm) + KMD);
+            delete(realm, getSupportIds(get(ids), ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getSupportIds(get(ids), KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, ids, mCollection);
         } finally {
             realm.close();
         }
         return i;
-    }
-
-    private List<String> getACLIds(Iterable<String> ids) {
-        List<T> items = get(ids);
-        List<String> ACLIds = new ArrayList<>();
-        for (T item : items) {
-            ACLIds.add((String)((GenericJson) item.get("_acl")).get("_id"));
-        }
-        return ACLIds;
-    }
-
-    private List<String> getKMDIds(Iterable<String> ids) {
-        List<T> items = get(ids);
-        List<String> ACLIds = new ArrayList<>();
-        for (T item : items) {
-            ACLIds.add((String)((GenericJson) item.get("_kmd")).get("_id"));
-        }
-        return ACLIds;
     }
 
     private int delete(DynamicRealm realm, Iterable<String> ids, String tableName) {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -280,8 +280,9 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
-            delete(realm, getACLIds(query), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getKMDIds(query), TableNameManager.getShortName(mCollection, realm) + KMD);
+            List<T> items = get(query);
+            delete(realm, getACLIds(items), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getKMDIds(items), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, query, mCollection);
         } finally {
             realm.close();
@@ -289,8 +290,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return i;
     }
 
-    private List<String> getACLIds(Query query) {
-        List<T> items = get(query);
+    private List<String> getACLIds(List<T> items) {
         List<String> ACLIds = new ArrayList<>();
         for (T item : items) {
             ACLIds.add((String)((GenericJson) item.get("_acl")).get("_id"));
@@ -298,8 +298,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return ACLIds;
     }
 
-    private List<String> getKMDIds(Query query) {
-        List<T> items = get(query);
+    private List<String> getKMDIds(List<T> items) {
         List<String> ACLIds = new ArrayList<>();
         for (T item : items) {
             ACLIds.add((String)((GenericJson) item.get("_kmd")).get("_id"));

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -280,13 +280,31 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
+            delete(realm, getACLIds(query), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getKMDIds(query), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, query, mCollection);
-            delete(realm, query, TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, query, TableNameManager.getShortName(mCollection, realm) + KMD);
         } finally {
             realm.close();
         }
         return i;
+    }
+
+    private List<String> getACLIds(Query query) {
+        List<T> items = get(query);
+        List<String> ACLIds = new ArrayList<>();
+        for (T item : items) {
+            ACLIds.add((String)((GenericJson) item.get("_acl")).get("_id"));
+        }
+        return ACLIds;
+    }
+
+    private List<String> getKMDIds(Query query) {
+        List<T> items = get(query);
+        List<String> ACLIds = new ArrayList<>();
+        for (T item : items) {
+            ACLIds.add((String)((GenericJson) item.get("_kmd")).get("_id"));
+        }
+        return ACLIds;
     }
 
     private int delete(DynamicRealm realm, Query query, String tableName) {
@@ -357,13 +375,31 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
+            delete(realm, getACLIds(ids), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getKMDIds(ids), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, ids, mCollection);
-            delete(realm, ids, TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, ids, TableNameManager.getShortName(mCollection, realm) + KMD);
         } finally {
             realm.close();
         }
         return i;
+    }
+
+    private List<String> getACLIds(Iterable<String> ids) {
+        List<T> items = get(ids);
+        List<String> ACLIds = new ArrayList<>();
+        for (T item : items) {
+            ACLIds.add((String)((GenericJson) item.get("_acl")).get("_id"));
+        }
+        return ACLIds;
+    }
+
+    private List<String> getKMDIds(Iterable<String> ids) {
+        List<T> items = get(ids);
+        List<String> ACLIds = new ArrayList<>();
+        for (T item : items) {
+            ACLIds.add((String)((GenericJson) item.get("_kmd")).get("_id"));
+        }
+        return ACLIds;
     }
 
     private int delete(DynamicRealm realm, Iterable<String> ids, String tableName) {
@@ -393,13 +429,23 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
+            delete(realm, getACLId(id), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getKMDId(id), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, id, mCollection);
-            delete(realm, id, TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, id, TableNameManager.getShortName(mCollection, realm) + KMD);
         } finally {
             realm.close();
         }
         return i;
+    }
+
+    private String getACLId(String id) {
+        T item = get(id);
+        return (String)((GenericJson) item.get("_acl")).get("_id");
+    }
+
+    private String getKMDId(String id) {
+        T item = get(id);
+        return (String)((GenericJson) item.get("_kmd")).get("_id");
     }
 
     private int delete(DynamicRealm realm, String id, String tableName) {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -315,7 +315,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                     }
                     realm.commitTransaction();
                     if (ids.size() > 0) {
-                        this.delete(realm, ids, mCollection);
+                        this.delete(realm, ids, tableName);
                     }
                 } else if (skip > 0) {
                     // only skip modifier has been applied, so take a subset of the Realm result set
@@ -327,7 +327,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                             ids.add((String) id.get(ID));
                         }
                         realm.commitTransaction();
-                        this.delete(realm, ids, mCollection);
+                        this.delete(realm, ids, tableName);
                     } else {
                         realm.commitTransaction();
                         ret = 0;
@@ -345,7 +345,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 for (T id : list) {
                     ids.add((String)id.get(ID));
                 }
-                delete(realm, ids, mCollection);
+                delete(realm, ids, tableName);
                 return ret;
             }
 
@@ -357,7 +357,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
-             i = delete(realm, ids, mCollection);
+            i = delete(realm, ids, mCollection);
             delete(realm, ids, TableNameManager.getShortName(mCollection, realm) + ACL);
             delete(realm, ids, TableNameManager.getShortName(mCollection, realm) + KMD);
         } finally {
@@ -371,7 +371,6 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         if (ids.iterator().hasNext()) {
             realm.beginTransaction();
             RealmQuery<DynamicRealmObject> query = realm.where(TableNameManager.getShortName(tableName, realm))
-                    .greaterThanOrEqualTo(ClassHash.TTL, Long.MAX_VALUE)
                     .beginGroup();
             Iterator<String> iterator = ids.iterator();
             if (iterator.hasNext()) {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -46,8 +46,8 @@ import io.realm.Sort;
  */
 public class RealmCache<T extends GenericJson> implements ICache<T> {
 
-    private static final String ACL = "__acl";
-    private static final String KMD = "__kmd";
+    private static final String ACL = "_acl";
+    private static final String KMD = "_kmd";
     private static final String ID = "_id";
 
     private String mCollection;
@@ -281,8 +281,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         int i;
         try {
             List<T> items = get(query);
-            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
+            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + "_" + ACL);
+            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + "_" + KMD);
             i = delete(realm, query, mCollection);
         } finally {
             realm.close();
@@ -373,8 +373,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         int i;
         try {
             List<T> items = get(ids);
-            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
+            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + "_" + ACL);
+            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + "_" + KMD);
             i = delete(realm, ids, mCollection);
         } finally {
             realm.close();
@@ -410,8 +410,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         int i;
         try {
             T item = get(id);
-            delete(realm, getSupportId(item, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getSupportId(item, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
+            delete(realm, getSupportId(item, ACL), TableNameManager.getShortName(mCollection, realm) + "_" + ACL);
+            delete(realm, getSupportId(item, KMD), TableNameManager.getShortName(mCollection, realm) + "_" + KMD);
             i = delete(realm, id, mCollection);
         } finally {
             realm.close();

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -299,9 +299,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
     private List<String> getSupportIds(List<T> items, String field) {
         List<String> supportIds = new ArrayList<>();
         for (T item : items) {
-            if (item.get(field) != null) {
-                supportIds.add((String) ((GenericJson) item.get(field)).get(ID));
-            }
+            supportIds.add(getSupportId(item, field));
         }
         return supportIds;
     }
@@ -374,8 +372,9 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
-            delete(realm, getSupportIds(get(ids), ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getSupportIds(get(ids), KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
+            List<T> items = get(ids);
+            delete(realm, getSupportIds(items, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getSupportIds(items, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, ids, mCollection);
         } finally {
             realm.close();
@@ -410,8 +409,9 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         DynamicRealm realm = mCacheManager.getDynamicRealm();
         int i;
         try {
-            delete(realm, getACLId(id), TableNameManager.getShortName(mCollection, realm) + ACL);
-            delete(realm, getKMDId(id), TableNameManager.getShortName(mCollection, realm) + KMD);
+            T item = get(id);
+            delete(realm, getSupportId(item, ACL), TableNameManager.getShortName(mCollection, realm) + ACL);
+            delete(realm, getSupportId(item, KMD), TableNameManager.getShortName(mCollection, realm) + KMD);
             i = delete(realm, id, mCollection);
         } finally {
             realm.close();
@@ -419,14 +419,8 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return i;
     }
 
-    private String getACLId(String id) {
-        T item = get(id);
-        return (String)((GenericJson) item.get("_acl")).get("_id");
-    }
-
-    private String getKMDId(String id) {
-        T item = get(id);
-        return (String)((GenericJson) item.get("_kmd")).get("_id");
+    private String getSupportId(T item, String field) {
+        return item.get(field) != null ? ((String) ((GenericJson) item.get(field)).get(ID)) : null;
     }
 
     private int delete(DynamicRealm realm, String id, String tableName) {

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -31,15 +31,13 @@ import com.kinvey.java.store.requests.data.PushRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteIdsRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteQueryRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteSingleRequest;
+import com.kinvey.java.store.requests.data.read.ReadAllRequest;
 import com.kinvey.java.store.requests.data.read.ReadCountRequest;
+import com.kinvey.java.store.requests.data.read.ReadIdsRequest;
+import com.kinvey.java.store.requests.data.read.ReadQueryRequest;
 import com.kinvey.java.store.requests.data.read.ReadSingleRequest;
 import com.kinvey.java.store.requests.data.save.SaveListRequest;
 import com.kinvey.java.store.requests.data.save.SaveRequest;
-import com.kinvey.java.store.requests.data.read.ReadAllRequest;
-import com.kinvey.java.store.requests.data.read.ReadIdsRequest;
-import com.kinvey.java.store.requests.data.read.ReadQueryRequest;
-import com.kinvey.java.sync.dto.SyncItem;
-import com.kinvey.java.sync.dto.SyncRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -358,19 +356,11 @@ public class BaseDataStore<T extends GenericJson> {
             int totalItemCount = this.countNetwork();
 
             networkData = new ArrayList<>();
-            List<T> page = new ArrayList<>();
             do {
                 query.setSkip(skipCount).setLimit(pageSize);
-                page = (Arrays.asList(networkManager.getBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute()));
-                networkData.addAll(page);
-
-                List<String> ids = new ArrayList<String>();
-                for (T id : page) {
-                    ids.add((String) id.get("_id"));
-                }
-//                cache.delete(ids);
+                networkData.addAll(Arrays.asList(networkManager.getBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute()));
                 cache.delete(query);
-                cache.save(page);
+                cache.save(networkData);
                 skipCount += pageSize;
             } while (skipCount < totalItemCount);
         } else {

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -358,11 +358,19 @@ public class BaseDataStore<T extends GenericJson> {
             int totalItemCount = this.countNetwork();
 
             networkData = new ArrayList<>();
+            List<T> page = new ArrayList<>();
             do {
                 query.setSkip(skipCount).setLimit(pageSize);
-                networkData.addAll(Arrays.asList(networkManager.getBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute()));
+                page = (Arrays.asList(networkManager.getBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute()));
+                networkData.addAll(page);
+
+                List<String> ids = new ArrayList<String>();
+                for (T id : page) {
+                    ids.add((String) id.get("_id"));
+                }
+//                cache.delete(ids);
                 cache.delete(query);
-                cache.save(networkData);
+                cache.save(page);
                 skipCount += pageSize;
             } while (skipCount < totalItemCount);
         } else {


### PR DESCRIPTION
#### Description
Exponential growth KDM every time a sync or pull is called was fixed

#### Changes
When autopagination was enabled, pull method has created new items in _kmd and _acl support tables even when items should be updated. It was fixed.

#### Tests
Manual
