### PR TITLE
feat: MLIBZ-2166 Upgrading from Android 3.0.5 to latest SDK crashes on data store methods

### DIFF
--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -45,6 +45,7 @@ import io.realm.DynamicRealmObject;
 import io.realm.FieldAttribute;
 import io.realm.RealmList;
 import io.realm.RealmObjectSchema;
+import io.realm.RealmSchema;
 
 /**
  * Created by Prots on 1/27/16.
@@ -164,6 +165,62 @@ public abstract class ClassHash {
         return schema;
     }
 
+    /**
+     * Migrate from old table name to new table name
+     * @param name table name to rename
+     * @param realm Realm object
+     * @param clazz Class in table
+     */
+    static void migration(String name, DynamicRealm realm, Class<? extends GenericJson> clazz){
+        rename(name, null, realm, clazz);
+    }
+
+    /**
+     * Rename realm table
+     * @param oldName old table name
+     * @param newName new table name
+     * @param realm Realm object
+     * @param clazz Class in table
+     */
+    private static void rename(String oldName, String newName,  DynamicRealm realm, Class<? extends GenericJson> clazz) {
+        String shortName = newName != null ? newName : TableNameManager.createShortName(oldName, realm);
+        RealmSchema schema = realm.getSchema();
+        schema.rename(oldName, shortName);
+        List<Field> fields = getClassFieldsAndParentClassFields(clazz);
+        for (Field f : fields){
+            FieldInfo fieldInfo = FieldInfo.of(f);
+            if (fieldInfo == null){
+                continue;
+            }
+            if (fieldInfo.getType().isArray() || Collection.class.isAssignableFrom(fieldInfo.getType())){
+                Class underlying = getUnderlying(f);
+                if (underlying != null && GenericJson.class.isAssignableFrom(underlying)){
+                    rename(oldName + "_" + fieldInfo.getName(), TableNameManager.createShortName(shortName + "_" + fieldInfo.getName(), realm), realm, (Class<? extends GenericJson>) fieldInfo.getType());
+                } else {
+                    for (Class c : ALLOWED) {
+                        if (underlying.equals(c)) {
+                            schema.rename(oldName, shortName);
+                            break;
+                        }
+                    }
+                }
+            } else if (GenericJson.class.isAssignableFrom(fieldInfo.getType())/* && !oldName.equals("sync") && !oldName.equals("syncitems")*/) {
+                rename(oldName + "_" + fieldInfo.getName(), TableNameManager.createShortName(shortName + "_" + fieldInfo.getName(), realm), realm, (Class<? extends GenericJson>) fieldInfo.getType());
+            }
+        }
+        if (schema.contains(oldName + "_" + KinveyMetaData.AccessControlList.ACL)) {
+            schema.rename(oldName + "_" + KinveyMetaData.AccessControlList.ACL,
+                    TableNameManager.createShortName(TableNameManager.getShortName(oldName, realm) + "_" + KinveyMetaData.AccessControlList.ACL, realm));
+        } else {
+            RealmObjectSchema objectSchema = schema.get(shortName);
+            RealmObjectSchema innerScheme = createSchemeFromClass(shortName + "_" + KinveyMetaData.AccessControlList.ACL, realm, KinveyMetaData.AccessControlList.class);
+            objectSchema.addRealmObjectField(KinveyMetaData.AccessControlList.ACL, innerScheme);
+        }
+        if (schema.contains(oldName + "_" + KinveyMetaData.KMD)) {
+            schema.rename(oldName + "_" + KinveyMetaData.KMD,
+                    TableNameManager.createShortName(shortName + "_" + KinveyMetaData.KMD, realm));
+        }
+    }
 
     private static RealmObjectSchema createSchemeFromClass(String name, DynamicRealm realm, Class<? extends GenericJson> clazz) {
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -204,7 +204,7 @@ public abstract class ClassHash {
                         }
                     }
                 }
-            } else if (GenericJson.class.isAssignableFrom(fieldInfo.getType())/* && !oldName.equals("sync") && !oldName.equals("syncitems")*/) {
+            } else if (GenericJson.class.isAssignableFrom(fieldInfo.getType())) {
                 rename(oldName + "_" + fieldInfo.getName(), TableNameManager.createShortName(shortName + "_" + fieldInfo.getName(), realm), realm, (Class<? extends GenericJson>) fieldInfo.getType());
             }
         }

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -522,6 +522,14 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         ClassHash.createScheme(mCollection, realm, mCollectionItemClass);
     }
 
+    /**
+     * Migrate from old table name to new table name
+     * @param realm Realm object
+     */
+    void migration(DynamicRealm realm){
+        ClassHash.migration(mCollection, realm, mCollectionItemClass);
+    }
+
     private String insertOrUpdate(T item, DynamicRealm mRealm){
 
         T clone = (T)item.clone();

--- a/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/TableNameManager.java
@@ -36,7 +36,7 @@ class TableNameManager {
     static String getShortName(String originalName, DynamicRealm realm) {
         initTable(realm);
         DynamicRealmObject realmObject = realm.where(COLLECTION_NAME).equalTo(ORIGINAL_NAME_FIELD, originalName).findFirst();
-        return realmObject.getString(SHORT_NAME_FIELD);
+        return realmObject != null ? realmObject.getString(SHORT_NAME_FIELD) : null;
     }
 
 }


### PR DESCRIPTION
#### Description
Add user data migration logic from 3.0.5 version

#### Changes
Added migration if user has old table name but doesn't have new table name (optimized name)

#### Tests
Checked manual in the test case:
User has 3.0.5 version. Also he has collection `Book` with some items and some items in `sync` collection in not pushed state. Class `Book` has inner class `Author`. User updated android kinvey library version to 3.0.9. After start application his inner tables was renamed to the new way. His data in `Book` and `sync` collection was saved and he can call `sync` to push his not synced items to the server. He shouldn't call `logout` to update table names.
