### PR TITLE
feat: MLIBZ-2070 no file meta data returned from store type.cache and a request to the backend is always made

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/FileStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/FileStoreTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -313,6 +314,18 @@ public class FileStoreTest {
         downloadFile(StoreType.SYNC);
     }
 
+    private FileOutputStream createOutputStream() {
+        try {
+            return new FileOutputStream(createFile("new_file.txt"));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     private KinveyCachedClientCallback<FileMetaData> createCachedClientCallback() {
         return new KinveyCachedClientCallback<FileMetaData>() {
             @Override
@@ -350,6 +363,7 @@ public class FileStoreTest {
                 try {
                     final FileOutputStream fos = new FileOutputStream(createFile());
                     client.getFileStore(storeType).download(metaFile, fos, listener,
+                            storeType == StoreType.CACHE ? createOutputStream() : null,
                             storeType == StoreType.CACHE ? createCachedClientCallback() : null);
                 } catch (IOException e) {
                     listener.onFailure(e);
@@ -792,6 +806,7 @@ public class FileStoreTest {
                 try {
                     final FileOutputStream fos = new FileOutputStream(createFile());
                     client.getFileStore(storeType).download(metaFile, fos, listener,
+                            storeType == StoreType.CACHE ? createOutputStream() : null,
                             storeType == StoreType.CACHE ? createCachedClientCallback() : null);
                     listener.isCancelled = true;
                     client.getFileStore(storeType).cancelDownloading();
@@ -810,6 +825,14 @@ public class FileStoreTest {
         File file = createFile();
         RandomAccessFile f = new RandomAccessFile(createFile(), "rw");
         f.setLength(mb * MB);
+        return file;
+    }
+
+    private File createFile(String fileName) throws IOException {
+        File file = new File(client.getContext().getFilesDir(), fileName);
+        if (!file.exists()) {
+            file.createNewFile();
+        }
         return file;
     }
 

--- a/java-api-core/src/com/kinvey/java/LinkedResources/GetLinkedResourceClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/LinkedResources/GetLinkedResourceClientRequest.java
@@ -117,7 +117,7 @@ public class GetLinkedResourceClientRequest<T> extends AbstractKinveyJsonClientR
                 FileMetaData meta = new FileMetaData();
                 if (((Map) entity.get(key)).containsKey("_id")){
                     meta.setId(((Map) entity.get(key)).get("_id").toString());
-                    store.download(meta, entity.getFile(key).getOutput(), null, download);
+                    store.download(meta, entity.getFile(key).getOutput(), null, null, download);
 
                 }/*else if(((Map) entity.get(key)).containsKey("_loc")){
                     meta.setFileName(((Map) entity.get(key)).get("_loc").toString());


### PR DESCRIPTION
#### Description
Fixed cached callback. User can get cached file path from FileMetaData object. 

#### Changes
Also a new method for downloading file was added. The new method has a OutputStream parameter for a cached file. 

#### Tests
Instrumented
