### PR TITLE
feat: MLIBZ-2134 Fix sync/pull with skip/limit in a query

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1035,6 +1035,21 @@ public class DataStoreTest {
         return callback;
     }
 
+    private DefaultKinveySyncCallback sync(final DataStore<Person> store, final Query query, int seconds) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final DefaultKinveySyncCallback callback = new DefaultKinveySyncCallback(latch);
+        LooperThread looperThread = new LooperThread(new Runnable() {
+            @Override
+            public void run() {
+                store.sync(query, callback);
+            }
+        });
+        looperThread.start();
+        latch.await(seconds, TimeUnit.SECONDS);
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
+    }
+
     @Test
     public void testSync() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
@@ -1487,6 +1502,190 @@ public class DataStoreTest {
         assertNotNull(pullResults);
         assertTrue(pullResults.size() == 3);
         assertTrue(pullResults.size() == getCacheSize(StoreType.CACHE));
+    }
+
+    @Test
+    public void testSkipLimitInPullBlocking() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.CACHE, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+
+        cleanBackendDataStore(store);
+
+        // Arrange
+        ArrayList<Person> persons = new ArrayList<>();
+        Person alvin = createPerson("Alvin");
+        Person simon = createPerson("Simon");
+        Person theodore = createPerson("Theodore");
+        Person anna = createPerson("Anna");
+        Person kate = createPerson("Kate");
+        save(store, alvin);
+        save(store, simon);
+        save(store, theodore);
+        save(store, anna);
+        save(store, kate);
+        long cacheSizeBefore = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBefore == 5);
+        client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
+        long cacheSizeBetween = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBetween == 0);
+
+        List<Person> pullResults = null;
+        Query query = client.query();
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            pullResults = store.pullBlocking(query).getResult();
+
+            assertNotNull(pullResults);
+            assertTrue(pullResults.size() == 1);
+            assertEquals(i+1, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            pullResults = store.pullBlocking(query).getResult();
+
+            assertNotNull(pullResults);
+            assertTrue(pullResults.size() == 1);
+            assertEquals(5, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+    }
+
+    @Test
+    public void testSkipLimitInPullAsync() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.CACHE, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+
+        cleanBackendDataStore(store);
+
+        // Arrange
+        ArrayList<Person> persons = new ArrayList<>();
+        Person alvin = createPerson("Alvin");
+        Person simon = createPerson("Simon");
+        Person theodore = createPerson("Theodore");
+        Person anna = createPerson("Anna");
+        Person kate = createPerson("Kate");
+        save(store, alvin);
+        save(store, simon);
+        save(store, theodore);
+        save(store, anna);
+        save(store, kate);
+        long cacheSizeBefore = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBefore == 5);
+        client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
+        long cacheSizeBetween = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBetween == 0);
+
+        List<Person> pullResults = null;
+        Query query = client.query();
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            pullResults = pull(store, query).result.getResult();
+
+            assertNotNull(pullResults);
+            assertTrue(pullResults.size() == 1);
+            assertEquals(i+1, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            pullResults = pull(store, query).result.getResult();
+
+            assertNotNull(pullResults);
+            assertTrue(pullResults.size() == 1);
+            assertEquals(5, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+    }
+
+    @Test
+    public void testSkipLimitInSyncBlocking() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.CACHE, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+
+        cleanBackendDataStore(store);
+
+        // Arrange
+        ArrayList<Person> persons = new ArrayList<>();
+        Person alvin = createPerson("Alvin");
+        Person simon = createPerson("Simon");
+        Person theodore = createPerson("Theodore");
+        Person anna = createPerson("Anna");
+        Person kate = createPerson("Kate");
+        save(store, alvin);
+        save(store, simon);
+        save(store, theodore);
+        save(store, anna);
+        save(store, kate);
+        long cacheSizeBefore = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBefore == 5);
+        client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
+        long cacheSizeBetween = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBetween == 0);
+
+        Query query = client.query();
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            store.syncBlocking(query);
+
+            assertEquals(i+1, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            store.syncBlocking(query);
+
+            assertEquals(5, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+    }
+
+    @Test
+    public void testSkipLimitInSyncAsync() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.CACHE, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+
+        cleanBackendDataStore(store);
+
+        // Arrange
+        ArrayList<Person> persons = new ArrayList<>();
+        Person alvin = createPerson("Alvin");
+        Person simon = createPerson("Simon");
+        Person theodore = createPerson("Theodore");
+        Person anna = createPerson("Anna");
+        Person kate = createPerson("Kate");
+        save(store, alvin);
+        save(store, simon);
+        save(store, theodore);
+        save(store, anna);
+        save(store, kate);
+        long cacheSizeBefore = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBefore == 5);
+        client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
+        long cacheSizeBetween = getCacheSize(StoreType.CACHE);
+        assertTrue(cacheSizeBetween == 0);
+
+        Query query = client.query();
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            sync(store, query, 120);
+            assertEquals(i+1, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
+        for (int i = 0; i < 5; i++) {
+            query.setLimit(1);
+            query.setSkip(i);
+            sync(store, query, 120);
+            assertEquals(5, getCacheSize(StoreType.CACHE));
+        }
+        assertEquals(5, getCacheSize(StoreType.CACHE));
     }
 
     @Test

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -49,6 +49,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
     private static final String ACL = "_acl";
     private static final String KMD = "_kmd";
     private static final String ID = "_id";
+    private static final String SORT_FIELD = "_kmd.ect";
 
     private String mCollection;
     private RealmCacheManager mCacheManager;
@@ -78,7 +79,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
             int limit = query.getLimit();
             int skip = query.getSkip();
 
-            objects = realmQuery.findAll();
+            objects = realmQuery.findAllSorted(SORT_FIELD);
 
             for (Iterator<DynamicRealmObject> iterator = objects.iterator(); iterator.hasNext(); ) {
                 DynamicRealmObject obj = iterator.next();
@@ -183,7 +184,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
             }
             query.endGroup();
 
-            RealmResults<DynamicRealmObject> objects = query.findAll();
+            RealmResults<DynamicRealmObject> objects = query.findAllSorted(SORT_FIELD);
 
             for (DynamicRealmObject obj : objects) {
                 ret.add(ClassHash.realmToObject(obj, mCollectionItemClass));
@@ -228,7 +229,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                     .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis());
 
             RealmResults<DynamicRealmObject> objects = query
-                    .findAll();
+                    .findAllSorted(SORT_FIELD);
 
             for (DynamicRealmObject obj : objects) {
                 ret.add(ClassHash.realmToObject(obj, mCollectionItemClass));
@@ -310,7 +311,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 RealmQuery<DynamicRealmObject> realmQuery = realm.where(TableNameManager.getShortName(tableName, realm));
                 QueryHelper.prepareRealmQuery(realmQuery, query.getQueryFilterMap());
 
-                RealmResults result = realmQuery.findAll();
+                RealmResults result = realmQuery.findAllSorted(SORT_FIELD);
 
                 ret = result.size();
                 int limit = query.getLimit();
@@ -600,7 +601,7 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
                 try {
                     objects = mRealm.where(TableNameManager.getShortName(mCollection, mRealm))
                             .greaterThanOrEqualTo(ClassHash.TTL, Calendar.getInstance().getTimeInMillis())
-                            .findAll();
+                            .findAllSorted(SORT_FIELD);
 
                 } finally {
                     mRealm.close();


### PR DESCRIPTION
#### Description
Not correct saving items to the cache if sync/pull methods are used with skip/limit parameters in a query. It happens because items are cleared not in correct order before sync/pull.

#### Changes
Added sort by `_kmd.ect` for getting items from the cache.

#### Tests
Instrumented
