### PR TITLE
feat: MLIBZ-2283 Fix setting request timeout

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
@@ -159,6 +160,13 @@ public class ClientBuilderTest {
             assertNotNull(e);
         }
         assertNull(client);
+    }
+
+    @Test
+    public void testSetTimeoutRequest() throws IOException {
+        client = new Client.Builder(mContext).setRequestTimeout(120000).build();
+        assertNotNull(client);
+        assertEquals(120000, client.getRequestTimeout());
     }
 
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/request/RequestTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/request/RequestTest.java
@@ -118,6 +118,7 @@ public class RequestTest {
 
         DefaultKinveyPushCallback pushCallback = testManager.push(store);
         assertNotNull(pushCallback);
+        assertNull(pushCallback.getResult());
         assertNotNull(pushCallback.getError());
         assertEquals("SocketTimeoutException", pushCallback.getError().getClass().getSimpleName());
     }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/request/RequestTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/request/RequestTest.java
@@ -1,0 +1,151 @@
+package com.kinvey.androidTest.request;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.RenamingDelegatingContext;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.util.Log;
+
+import com.google.api.client.http.HttpTransport;
+import com.kinvey.android.Client;
+import com.kinvey.android.store.DataStore;
+import com.kinvey.androidTest.TestManager;
+import com.kinvey.androidTest.callback.CustomKinveySyncCallback;
+import com.kinvey.androidTest.callback.DefaultKinveyClientCallback;
+import com.kinvey.androidTest.callback.DefaultKinveyPushCallback;
+import com.kinvey.androidTest.model.Person;
+import com.kinvey.java.store.StoreType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+import static com.kinvey.androidTest.TestManager.PASSWORD;
+import static com.kinvey.androidTest.TestManager.TEST_USERNAME;
+import static com.kinvey.androidTest.TestManager.USERNAME;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by yuliya on 1/5/17.
+ */
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class RequestTest {
+
+    private static final int DEFAULT_TIMEOUT = 60 * 1000;
+
+    private Client client;
+    private TestManager<Person> testManager;
+    private DataStore<Person> store;
+
+    @Before
+    public void setUp() throws InterruptedException, IOException {
+        Context mMockContext = new RenamingDelegatingContext(InstrumentationRegistry.getInstrumentation().getTargetContext(), "test_");
+        client = new Client.Builder(mMockContext).build();
+        testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+
+    }
+
+    @After
+    public void tearDown() {
+        client.performLockDown();
+        if (client.getKinveyHandlerThread() != null) {
+            try {
+                client.stopKinveyHandlerThread();
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
+        }
+    }
+
+
+    @Test
+    public void testDefaultTimeOutValue() throws InterruptedException, IOException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        client.enableDebugLogging();
+        assertEquals(DEFAULT_TIMEOUT, client.getRequestTimeout());
+
+        Person person = new Person();
+        person.setUsername(TEST_USERNAME);
+        DefaultKinveyClientCallback callback = testManager.save(store, person);
+        assertNotNull(callback);
+        assertNotNull(callback.getResult());
+        assertNull(callback.getError());
+        assertNotNull(callback.getResult().getUsername());
+        assertEquals(TEST_USERNAME, callback.getResult().getUsername());
+
+        DefaultKinveyPushCallback pushCallback = testManager.push(store);
+        assertNotNull(pushCallback);
+        assertNotNull(pushCallback.getResult());
+        assertNull(pushCallback.getError());
+        assertEquals(1, pushCallback.getResult().getSuccessCount());
+    }
+
+    @Test
+    public void testSetCustomTimeoutAndCheckException() throws InterruptedException, IOException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        assertEquals(DEFAULT_TIMEOUT, client.getRequestTimeout());
+
+        client.setRequestTimeout(1);
+        assertEquals(1, client.getRequestTimeout());
+
+        Person person = new Person();
+        person.setUsername(TEST_USERNAME);
+        DefaultKinveyClientCallback callback = testManager.save(store, person);
+        assertNotNull(callback);
+        assertNotNull(callback.getResult());
+        assertNull(callback.getError());
+        assertNotNull(callback.getResult().getUsername());
+        assertEquals(TEST_USERNAME, callback.getResult().getUsername());
+
+        DefaultKinveyPushCallback pushCallback = testManager.push(store);
+        assertNotNull(pushCallback);
+        assertNotNull(pushCallback.getError());
+        assertEquals("SocketTimeoutException", pushCallback.getError().getClass().getSimpleName());
+    }
+
+    @Test
+    public void testSetCustomTimeout() throws InterruptedException, IOException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        assertEquals(DEFAULT_TIMEOUT, client.getRequestTimeout());
+
+        client.setRequestTimeout(DEFAULT_TIMEOUT * 2);
+        assertEquals(DEFAULT_TIMEOUT * 2, client.getRequestTimeout());
+
+        Person person = new Person();
+        person.setUsername(TEST_USERNAME);
+        DefaultKinveyClientCallback callback = testManager.save(store, person);
+        assertNotNull(callback);
+        assertNotNull(callback.getResult());
+        assertNull(callback.getError());
+        assertNotNull(callback.getResult().getUsername());
+        assertEquals(TEST_USERNAME, callback.getResult().getUsername());
+
+        DefaultKinveyPushCallback pushCallback = testManager.push(store);
+        assertNotNull(pushCallback);
+        assertNotNull(pushCallback.getResult());
+        assertNull(pushCallback.getError());
+        assertEquals(1, pushCallback.getResult().getSuccessCount());
+    }
+
+
+}

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -795,6 +795,7 @@ public class Client<T extends User> extends AbstractClient<T> {
                 client.enableDebugLogging();
             }
 
+            client.setRequestTimeout(this.requestTimeout);
             client.syncRate = this.syncRate;
             client.batchRate = this.batchRate;
             client.batchSize = this.batchSize;

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -769,6 +769,14 @@ public class Client<T extends User> extends AbstractClient<T> {
         }
 
         /**
+         * @param requestTimeout - the request timeout
+         */
+        public Builder setRequestTimeout(int requestTimeout) {
+            super.setRequestTimeout(requestTimeout);
+            return this;
+        }
+
+        /**
          * @return an instantiated Kinvey Android Client,
          * which contains factory methods for accessing various functionality.
          */

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -450,6 +450,9 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
             return getProps().getProperty(opt.value, defaultValue);
         }
 
+        /**
+         * @param requestTimeout - the request timeout
+         */
         public Builder setRequestTimeout(int requestTimeout) {
             this.requestTimeout = requestTimeout;
             return this;

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -62,6 +62,11 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
      * The default encoded service path of the service.
      */
     public static final String DEFAULT_SERVICE_PATH = "";
+
+    /**
+     * The default request timeout is 60s.
+     */
+    public static final int DEFAULT_REQUEST_TIMEOUT = 60 * 1000;
     
     private CredentialStore store;
 
@@ -313,7 +318,7 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
     public static abstract class Builder extends AbstractKinveyJsonClient.Builder {
         private CredentialStore store;
         private Properties props = new Properties();
-        private int requestTimeout;
+        protected int requestTimeout = DEFAULT_REQUEST_TIMEOUT;
         public boolean useDeltaCache;
 
         /**

--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
@@ -268,6 +268,8 @@ public abstract class AbstractKinveyClientRequest<T> extends GenericData {
                 .buildRequest(requestMethod, buildHttpRequestUrl(), httpContent);
         httpRequest.setParser(getAbstractKinveyClient().getObjectParser());
         httpRequest.setSuppressUserAgentSuffix(true);
+        httpRequest.setConnectTimeout(client.getRequestTimeout());
+        httpRequest.setReadTimeout(client.getRequestTimeout());
         //httpRequest.setRetryOnExecuteIOException(true);
         //httpRequest.setBackOffPolicy(this.requestBackoffPolicy);
         // custom methods may use POST with no content but require a Content-Length header


### PR DESCRIPTION
#### Description
`Client.setRequestTimeout` method didn't affect to request timeout. It was fixed.

#### Changes
Call `setRuestTimeout` was added  to `Client.Builder.build` method.
Default request timeout was updated from 20s to 60s.

#### Tests
Instrumented, manual.
