### PR TITLE
feat: MLIBZ-2302 Investigate performance of realm cache inserts

### DIFF
--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.java
@@ -72,10 +72,10 @@ public abstract class AbstractKinveyReadRequest<T> extends AbstractKinveyJsonCli
                 return null;
 
             } else {
-                JsonParser jsonParser = new JsonParser();
                 InputStreamReader streamReader = new InputStreamReader(response.getContent(), "UTF-8");
-                JsonArray jsonArray = (JsonArray) jsonParser.parse(CharStreams.toString(streamReader));
+                JsonArray jsonArray = (JsonArray) new JsonParser().parse(CharStreams.toString(streamReader));
                 streamReader.close();
+                streamReader = null;
                 JsonObjectParser objectParser = getAbstractKinveyClient().getObjectParser();
                 for (JsonElement element : jsonArray) {
                     try {

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Query;
 import com.kinvey.java.annotations.ReferenceHelper;
+import com.kinvey.java.cache.ICache;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.core.AbstractKinveyReadRequest;
 import com.kinvey.java.deltaset.DeltaSetItem;
@@ -302,11 +303,36 @@ public class NetworkManager<T extends GenericJson> {
         return getBlocking(new Query());
     }
 
+    /**
+     * @deprecated use {@link #pullBlocking(Query, ICache, boolean)} ()} instead.
+     */
+    @Deprecated
     public Pull pullBlocking(Query query, List<T> cachedItems, boolean deltaSetCachingEnabled) throws IOException {
         Preconditions.checkNotNull(query);
         Pull pull;
         if (deltaSetCachingEnabled) {
             pull = new DeltaPull(query, myClass, cachedItems);
+        } else {
+            pull = new Pull(query, myClass);
+        }
+        client.initializeRequest(pull);
+        return pull;
+    }
+
+    /**
+     *  Method to create a Pull request
+     *
+     * @param query Query to get
+     * @param cache Cache
+     * @param deltaSetCachingEnabled Flag to show if Delta Set Caching is enable
+     * @return Pull request
+     * @throws IOException
+     */
+    public Pull pullBlocking(Query query, ICache<T> cache, boolean deltaSetCachingEnabled) throws IOException {
+        Preconditions.checkNotNull(query);
+        Pull pull;
+        if (deltaSetCachingEnabled) {
+            pull = new DeltaPull(query, myClass, cache.get(query));
         } else {
             pull = new Pull(query, myClass);
         }

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -383,7 +383,7 @@ public class BaseDataStore<T extends GenericJson> {
             KinveyAbstractReadResponse<T> pullResponse;
             do {
                 query.setSkip(skipCount).setLimit(pageSize);
-                pullResponse = networkManager.pullBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute();
+                pullResponse = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
                 networkData.addAll(pullResponse.getResult());
                 exceptions.addAll(pullResponse.getListOfExceptions());
                 cache.delete(query);
@@ -393,7 +393,7 @@ public class BaseDataStore<T extends GenericJson> {
             response.setResult(networkData);
             response.setListOfExceptions(exceptions);
         } else {
-            response = networkManager.pullBlocking(query, cache.get(query), isDeltaSetCachingEnabled()).execute();
+            response = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
             cache.delete(query);
             cache.save(response.getResult());
         }


### PR DESCRIPTION
#### Description
Updated `pullBlocking` signature

#### Changes
`cache.get(query)` is needed only in case if `DeltaSetCache` is enabled. This call was removed for the case `DeltaSetCache` is disabled. It affects the time for Pull request initializing.

#### Tests
Manual, Instrumented
