### PR TITLE
MLIBZ-2299 Change response retrieval method from conversion of input …

### DIFF
--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyReadRequest.java
@@ -69,7 +69,7 @@ public abstract class AbstractKinveyReadRequest<T> extends AbstractKinveyJsonCli
                 return null;
 
             } else {
-                String jsonString = convertStreamToString(response.getContent());
+                String jsonString = response.parseAsString();
                 JsonParser jsonParser = new JsonParser();
                 JsonArray jsonArray = (JsonArray) jsonParser.parse(jsonString);
                 for (JsonElement element : jsonArray) {
@@ -94,10 +94,5 @@ public abstract class AbstractKinveyReadRequest<T> extends AbstractKinveyJsonCli
         } catch (NullPointerException ex){
             return null;
         }
-    }
-
-    private String convertStreamToString(java.io.InputStream is) {
-        java.util.Scanner s = new java.util.Scanner(is).useDelimiter("\\A");
-        return s.hasNext() ? s.next() : "";
     }
 }


### PR DESCRIPTION
#### Description
Looking to improve the processing time of response content from the server. This PR focuses on trying to improve the conversion of the response into an `InputStream`, which then gets written to a `String`.

#### Changes
The `HttpResponse` object returned from the network request contains a method called `parseAsString`, which returns the same result as the previously used `convertStreamToString`, without having to get an `InputStream` first.

#### Tests
Previously existing instrumented test verify the correctness of this change, and performance tests are performed manually on physical devices.
