### PR TITLE
feat: MLIBZ-2318 Add sorting for tests with items order checking

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1670,7 +1670,7 @@ public class DataStoreTest {
         client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.SYNC.ttl).clear();
 
         List<Person> pullResults;
-        Query query = client.query().addSort("_kmd", AbstractQuery.SortOrder.ASC);
+        Query query = client.query().addSort(KMD, AbstractQuery.SortOrder.ASC);
         query.setLimit(1);
         for (int i = 0; i < 5; i++) {
             query.setSkip(i);
@@ -1695,7 +1695,7 @@ public class DataStoreTest {
             }
             sync(store, DEFAULT_TIMEOUT);
             Query query = client.query();
-            query.setLimit(1).addSort("_kmd", AbstractQuery.SortOrder.ASC);
+            query.setLimit(1).addSort(KMD, AbstractQuery.SortOrder.ASC);
             for (int i = 0; i < 5; i++) {
                 query.setSkip(i);
                 pullResults = pull(store, query).result.getResult();

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1670,7 +1670,7 @@ public class DataStoreTest {
         client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.SYNC.ttl).clear();
 
         List<Person> pullResults;
-        Query query = client.query();
+        Query query = client.query().addSort("_kmd", AbstractQuery.SortOrder.ASC);
         query.setLimit(1);
         for (int i = 0; i < 5; i++) {
             query.setSkip(i);
@@ -1695,13 +1695,14 @@ public class DataStoreTest {
             }
             sync(store, DEFAULT_TIMEOUT);
             Query query = client.query();
-            query.setLimit(1).addSort("_kmd.ect", AbstractQuery.SortOrder.ASC);
+            query.setLimit(1).addSort("_kmd", AbstractQuery.SortOrder.ASC);
             for (int i = 0; i < 5; i++) {
                 query.setSkip(i);
                 pullResults = pull(store, query).result.getResult();
                 assertNotNull(pullResults);
                 assertTrue(pullResults.size() == 1);
                 assertEquals(5, getCacheSize(StoreType.SYNC));
+                assertEquals(pullResults.get(0).getUsername(), TEST_USERNAME + "_" + i);
             }
             System.out.println("TEST: number - " + j);
             assertEquals(5, getCacheSize(StoreType.SYNC));

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
@@ -14,6 +14,8 @@ import com.kinvey.androidTest.callback.CustomKinveySyncCallback;
 import com.kinvey.androidTest.callback.DefaultKinveyClientCallback;
 import com.kinvey.androidTest.callback.DefaultKinveyDeleteCallback;
 import com.kinvey.androidTest.model.Person;
+import com.kinvey.java.Query;
+import com.kinvey.java.query.AbstractQuery;
 import com.kinvey.java.store.StoreType;
 
 import org.junit.After;
@@ -149,7 +151,8 @@ public class DeltaCacheTest {
         testManager.createPersons(store, TEN_ITEMS);
 
         store.pushBlocking();
-        List<Person> pulledPersons = store.pullBlocking(client.query()).getResult();
+        Query query = client.query().addSort("_kmd", AbstractQuery.SortOrder.ASC);
+        List<Person> pulledPersons = store.pullBlocking(query).getResult();
         assertNotNull(pulledPersons);
         assertEquals(TEN_ITEMS, pulledPersons.size());
 
@@ -159,7 +162,7 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        pulledPersons = store.pullBlocking(client.query()).getResult();
+        pulledPersons = store.pullBlocking(query).getResult();
         assertNotNull(pulledPersons);
         assertEquals(TEN_ITEMS, pulledPersons.size());
 
@@ -168,7 +171,7 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        List<Person> foundPersons = testManager.find(store, client.query()).getResult();
+        List<Person> foundPersons = testManager.find(store, query).getResult();
         assertNotNull(foundPersons);
         assertEquals(TEN_ITEMS, foundPersons.size());
 
@@ -190,7 +193,8 @@ public class DeltaCacheTest {
 
         store.clear();
 
-        List<Person> pulledPersons = store.pullBlocking(client.query()).getResult();
+        Query query = client.query().addSort("_kmd", AbstractQuery.SortOrder.ASC);
+        List<Person> pulledPersons = store.pullBlocking(query).getResult();
         assertNotNull(pulledPersons);
         assertEquals(TEN_ITEMS, pulledPersons.size());
 
@@ -200,7 +204,7 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        pulledPersons = store.pullBlocking(client.query()).getResult();
+        pulledPersons = store.pullBlocking(query).getResult();
         assertNotNull(pulledPersons);
         assertEquals(TEN_ITEMS, pulledPersons.size());
 
@@ -209,7 +213,7 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        List<Person> foundPersons = testManager.find(store, client.query()).getResult();
+        List<Person> foundPersons = testManager.find(store, query).getResult();
         assertNotNull(foundPersons);
         assertEquals(TEN_ITEMS, foundPersons.size());
 
@@ -568,12 +572,12 @@ public class DeltaCacheTest {
         assertNull(saveCallback.getError());
         assertEquals(TEST_USERNAME + 100, saveCallback.getResult().getUsername());
 
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, client.query());
+        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, client.query().addSort("_kmd", AbstractQuery.SortOrder.ASC));
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
         assertEquals(TEN_ITEMS, pullCallback.getResult().getResult().size());
-        assertEquals(TEST_USERNAME + 100, pullCallback.getResult().getResult().get(0).getUsername());
+        assertEquals(TEST_USERNAME + 100, pullCallback.getResult().getResult().get(9).getUsername());
 
         List<Person> personList = testManager.find(store, client.query().equals("username", TEST_USERNAME + 100)).getResult();
         assertEquals(1, personList.size());

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
@@ -243,7 +243,7 @@ public class DeltaCacheTest {
         }
 
         store.pushBlocking();
-        List<Person> pulledPersons = store.pullBlocking(client.query().equals("age", "30")).getResult();
+        List<Person> pulledPersons = store.pullBlocking(client.query().equals("age", "30").addSort("_kmd", AbstractQuery.SortOrder.ASC)).getResult();
         assertNotNull(pulledPersons);
         assertEquals(TEN_ITEMS, pulledPersons.size());
 
@@ -253,7 +253,7 @@ public class DeltaCacheTest {
             assertEquals("DeltaCacheUserNameQuery_" + i, person.getUsername());
         }
 
-        List<Person> foundPersons = testManager.find(store, client.query().equals("age", "30")).getResult();
+        List<Person> foundPersons = testManager.find(store, client.query().equals("age", "30").addSort("_kmd", AbstractQuery.SortOrder.ASC)).getResult();
 
         Person person1;
         for (int i = 0; i < TEN_ITEMS; i++) {

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -376,7 +376,7 @@ public class BaseDataStore<T extends GenericJson> {
 
         if (isAutoPaginationEnabled()) {
             if (query.getSortString() == null || query.getSortString().isEmpty()) {
-                query.addSort(KinveyMetaData.KMD, AbstractQuery.SortOrder.ASC);
+                query.addSort(KinveyMetaData.KMD + "." + KinveyMetaData.ECT, AbstractQuery.SortOrder.ASC);
             }
             List<T> networkData = new ArrayList<T>();
             List<Exception> exceptions = new ArrayList<Exception>();

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -374,9 +374,9 @@ public class BaseDataStore<T extends GenericJson> {
         query = query == null ? client.query() : query;
 
         if (isAutoPaginationEnabled()) {
-/*            if (query.getSortString() == null || query.getSortString().isEmpty()) {
+            if (query.getSortString() == null || query.getSortString().isEmpty()) {
                 query.addSort("_kmd", AbstractQuery.SortOrder.ASC);
-            }*/
+            }
             List<T> networkData = new ArrayList<T>();
             List<Exception> exceptions = new ArrayList<Exception>();
             int skipCount = 0;

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -26,6 +26,7 @@ import com.kinvey.java.core.KinveyCachedAggregateCallback;
 import com.kinvey.java.model.AggregateType;
 import com.kinvey.java.model.Aggregation;
 import com.kinvey.java.model.KinveyAbstractReadResponse;
+import com.kinvey.java.model.KinveyMetaData;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.query.AbstractQuery;
 import com.kinvey.java.store.requests.data.AggregationRequest;
@@ -375,7 +376,7 @@ public class BaseDataStore<T extends GenericJson> {
 
         if (isAutoPaginationEnabled()) {
             if (query.getSortString() == null || query.getSortString().isEmpty()) {
-                query.addSort("_kmd", AbstractQuery.SortOrder.ASC);
+                query.addSort(KinveyMetaData.KMD, AbstractQuery.SortOrder.ASC);
             }
             List<T> networkData = new ArrayList<T>();
             List<Exception> exceptions = new ArrayList<Exception>();

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -27,6 +27,7 @@ import com.kinvey.java.model.AggregateType;
 import com.kinvey.java.model.Aggregation;
 import com.kinvey.java.model.KinveyAbstractReadResponse;
 import com.kinvey.java.network.NetworkManager;
+import com.kinvey.java.query.AbstractQuery;
 import com.kinvey.java.store.requests.data.AggregationRequest;
 import com.kinvey.java.store.requests.data.PushRequest;
 import com.kinvey.java.store.requests.data.delete.DeleteIdsRequest;
@@ -373,6 +374,9 @@ public class BaseDataStore<T extends GenericJson> {
         query = query == null ? client.query() : query;
 
         if (isAutoPaginationEnabled()) {
+/*            if (query.getSortString() == null || query.getSortString().isEmpty()) {
+                query.addSort("_kmd", AbstractQuery.SortOrder.ASC);
+            }*/
             List<T> networkData = new ArrayList<T>();
             List<Exception> exceptions = new ArrayList<Exception>();
             int skipCount = 0;


### PR DESCRIPTION
#### Description
For correct work `skip` parameter a user have to add sorting to the query. 
If autopagination is enabled, sorting should work correct without any additinal action from the user side.

#### Changes
Added sorting for tests with items order checking. Also sorting was added in autopagination logic. 
In autopagination case SDK didn't lose user data without sorting, but had not correct items order as well.

#### Tests
Instrumented
