### PR TITLE
feat: MLIBZ-2339 Add support for null nested objects

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -2967,7 +2967,6 @@ public class DataStoreTest {
         person.setUsername("person_name");
         List<PersonList> list = new ArrayList<>();
         list.add(new PersonList("person_name_in_list_1"));
-        list.add(null);
         person.setList(list);
         store.save(person);
 

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -598,7 +599,7 @@ public abstract class ClassHash {
                     object.setList(fieldInfo.getName(), list);
 
                 }
-            } else if (GenericJson.class.isAssignableFrom(fieldInfo.getType()) && fieldInfo.getValue(obj) != null){
+            } else if (GenericJson.class.isAssignableFrom(fieldInfo.getType())){
                 if (!f.getType().getSimpleName().equalsIgnoreCase(clazz.getSimpleName())) {
                     state = selfReferenceState;
                 } else if (selfReferenceState == SelfReferenceState.DEFAULT) {
@@ -609,14 +610,20 @@ public abstract class ClassHash {
 //                        selfRefClass = clazz;
                 }
                 if (state != null) {
-                    DynamicRealmObject innerObject = saveClassData(
-                            selfReferenceState == SelfReferenceState.SUBCLASS &&
-                                    classes.contains(f.getType().getSimpleName()) ? name : shortName + "_" + fieldInfo.getName(),
-                            realm,
-                            (Class<? extends GenericJson>) fieldInfo.getType(),
-                            (GenericJson) obj.get(fieldInfo.getName()),
-                            state, classesList);
-                    object.setObject(fieldInfo.getName(), innerObject);
+                    if (fieldInfo.getValue(obj) != null) {
+                        DynamicRealmObject innerObject = saveClassData(
+                                selfReferenceState == SelfReferenceState.SUBCLASS &&
+                                        classes.contains(f.getType().getSimpleName()) ? name : shortName + "_" + fieldInfo.getName(),
+                                realm,
+                                (Class<? extends GenericJson>) fieldInfo.getType(),
+                                (GenericJson) obj.get(fieldInfo.getName()),
+                                state, classesList);
+                        object.setObject(fieldInfo.getName(), innerObject);
+                    } else {
+                        if (object.hasField(fieldInfo.getName())) {
+                            object.setNull(fieldInfo.getName());
+                        }
+                    }
                 }
             } else {
                 if (!fieldInfo.getName().equals(ID)) {
@@ -637,9 +644,9 @@ public abstract class ClassHash {
 
         if (!obj.containsKey(KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.KMD) && !name.endsWith("_" + KinveyMetaData.AccessControlList.ACL)){
             KinveyMetaData metadata = new KinveyMetaData();
-            metadata.set("lmt", String.format("%tFT%<tTZ",
+            metadata.set("lmt", String.format(Locale.US, "%tFT%<tTZ",
                     Calendar.getInstance(TimeZone.getTimeZone("Z"))));
-            metadata.set("ect", String.format("%tFT%<tTZ",
+            metadata.set("ect", String.format(Locale.US, "%tFT%<tTZ",
                     Calendar.getInstance(TimeZone.getTimeZone("Z"))));
 
             DynamicRealmObject innerObject = saveClassData(shortName + "_" + KinveyMetaData.KMD,

--- a/java-api-core/src/com/kinvey/java/model/KinveyMetaData.java
+++ b/java-api-core/src/com/kinvey/java/model/KinveyMetaData.java
@@ -22,6 +22,7 @@ import com.kinvey.java.AbstractClient;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -61,13 +62,13 @@ public class KinveyMetaData extends GenericJson{
         KinveyMetaData metaData = new KinveyMetaData();
         if (kmd != null) {
             if (!kmd.containsKey(LMT) || kmd.get(LMT) == null) {
-                metaData.put(LMT, String.format("%tFT%<tTZ",
+                metaData.put(LMT, String.format(Locale.US, "%tFT%<tTZ",
                         Calendar.getInstance(TimeZone.getTimeZone("Z"))));
             } else {
                 metaData.put(LMT, kmd.get(LMT));
             }
             if (!kmd.containsKey(ECT) || kmd.get(ECT) == null) {
-                metaData.put(ECT, String.format("%tFT%<tTZ",
+                metaData.put(ECT, String.format(Locale.US, "%tFT%<tTZ",
                         Calendar.getInstance(TimeZone.getTimeZone("Z"))));
             } else {
                 metaData.put(ECT, kmd.get(ECT));


### PR DESCRIPTION
#### Description
User could not set null to the nested object and save it. SDK has ignored that nested object was changed to null.

#### Changes
SDK has ignored fields with null objects, this logic was updated. Currently If an object has a field with a null object it will be saved to the realm object in the field with a null value.

#### Tests
Instrumented
