### PR TITLE
MLIBZ-2269 

### DIFF
--- a/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
+++ b/java-api-core/src/com/kinvey/java/core/AbstractKinveyClientRequest.java
@@ -332,7 +332,6 @@ public abstract class AbstractKinveyClientRequest<T> extends GenericData {
             request.setFollowRedirects(false);
         }
 
-
         response = request.execute();
 
         lastResponseCode = response.getStatusCode();
@@ -344,18 +343,17 @@ public abstract class AbstractKinveyClientRequest<T> extends GenericData {
         }
 
         //process refresh token needed
-        if (response.getStatusCode() == 401 && !hasRetryed){
-
-
+        if (response.getStatusCode() == 401 && !hasRetryed) {
             //get the refresh token
             Credential cred = client.getStore().load(client.getActiveUser().getId());
             String refreshToken = null;
-            if (cred != null){
+
+            if (cred != null) {
                 refreshToken = cred.getRefreshToken();
             }
 
-            if (refreshToken != null ){
-                //logout the current user
+            if (refreshToken != null) {
+                hasRetryed = true;
                 String appKey = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppKey();
                 String appSecret = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppSecret();
 
@@ -364,10 +362,11 @@ public abstract class AbstractKinveyClientRequest<T> extends GenericData {
 
                 UserStoreRequestManager userStoreRequestManager = new UserStoreRequestManager(client, builder);
 
-                userStoreRequestManager.logout().execute();
-
                 //use the refresh token for a new access token
                 GenericJson result = userStoreRequestManager.useRefreshToken(refreshToken).execute();
+
+                // soft logout the current user
+                userStoreRequestManager.logoutSoft().execute();
 
                 //login with the access token
                 userStoreRequestManager.loginMobileIdentityBlocking(result.get("access_token").toString()).execute();
@@ -376,7 +375,7 @@ public abstract class AbstractKinveyClientRequest<T> extends GenericData {
                 Credential currentCred = client.getStore().load(client.getActiveUser().getId());
                 currentCred.setRefreshToken(result.get("refresh_token").toString());
                 client.getStore().store(client.getActiveUser().getId(), currentCred);
-                hasRetryed = true;
+                currentCred.initialize(this);
                 return executeUnparsed();
             }
 

--- a/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
+++ b/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
@@ -42,6 +42,7 @@ import com.kinvey.java.store.requests.user.GetMICTempURL;
 import com.kinvey.java.store.requests.user.LockDownUser;
 import com.kinvey.java.store.requests.user.LoginToTempURL;
 import com.kinvey.java.store.requests.user.LogoutRequest;
+import com.kinvey.java.store.requests.user.LogoutSoftRequest;
 import com.kinvey.java.store.requests.user.ResetPassword;
 import com.kinvey.java.store.requests.user.Retrieve;
 import com.kinvey.java.store.requests.user.RetrieveUsers;
@@ -381,6 +382,16 @@ public class UserStoreRequestManager<T extends BaseUser> {
      */
     public LogoutRequest logout() {
         return new LogoutRequest(client);
+    }
+
+    /**
+     * Logs the user out of the current app without removing the user credential. For internal use.
+     *
+     * @return LogoutRequest object
+     * @throws IOException
+     */
+    public LogoutSoftRequest logoutSoft() {
+        return new LogoutSoftRequest(client);
     }
 
     /**

--- a/java-api-core/src/com/kinvey/java/store/requests/user/LogoutSoftRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/user/LogoutSoftRequest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2018, Kinvey, Inc. All rights reserved.
+ *
+ * This software is licensed to you under the Kinvey terms of service located at
+ * http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+ * software, you hereby accept such terms of service  (and any agreement referenced
+ * therein) and agree that you have read, understand and agree to be bound by such
+ * terms of service and are of legal age to agree to such terms with Kinvey.
+ *
+ * This software contains valuable confidential and proprietary information of
+ * KINVEY, INC and is subject to applicable licensing agreements.
+ * Unauthorized reproduction, transmission or distribution of this file and its
+ * contents is a violation of applicable laws.
+ *
+ */
+
+package com.kinvey.java.store.requests.user;
+
+import com.kinvey.java.AbstractClient;
+
+/**
+ * Logout Request Class for soft logout.  Constructs the HTTP request object for soft logout
+ * requests. For internal SDK use only.
+ */
+
+public final class LogoutSoftRequest {
+
+    private AbstractClient client;
+
+    public LogoutSoftRequest(AbstractClient client) {
+        this.client = client;
+    }
+
+    public void execute() {
+        client.setActiveUser(null);
+    }
+}


### PR DESCRIPTION
#### Description
After an auth token expires and the refresh token flow starts, the attempt to retrieve a new refresh token would exception out. This is due to a hard logout of the active user.

#### Changes
Change logout in refresh token retry to be soft, and re-initialize the request to ensure latest auth token is used.

#### Tests
Manual testing to initiate refresh token flow.