### PR TITLE
feat: MLIBZ-2328 Add support for long names in fields with List type

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonLongListName.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonLongListName.java
@@ -1,0 +1,30 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.util.Key;
+
+import java.util.List;
+
+public class PersonLongListName extends Person{
+
+    @Key("sub_industry_ids")
+    private List<String> list;
+
+    @Key("author_list_test_field")
+    private List<Author> authors;
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+
+    public List<Author> getAuthors() {
+        return authors;
+    }
+
+    public void setAuthors(List<Author> authors) {
+        this.authors = authors;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonOver63CharsInFieldName.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonOver63CharsInFieldName.java
@@ -1,0 +1,13 @@
+package com.kinvey.androidTest.model;
+
+
+import com.google.api.client.util.Key;
+
+import java.util.List;
+
+public class PersonOver63CharsInFieldName extends Person{
+
+    @Key(LONG_NAME)
+    private List<String> list;
+
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -35,6 +35,8 @@ import com.kinvey.androidTest.model.Author;
 import com.kinvey.androidTest.model.LongClassNameLongClassNameLongClassNameLongClassNameLongClassName;
 import com.kinvey.androidTest.model.Person;
 import com.kinvey.androidTest.model.Person56;
+import com.kinvey.androidTest.model.PersonLongListName;
+import com.kinvey.androidTest.model.PersonOver63CharsInFieldName;
 import com.kinvey.androidTest.util.RealmCacheManagerUtil;
 import com.kinvey.androidTest.model.PersonList;
 import com.kinvey.androidTest.model.PersonRoomAddressPerson;
@@ -514,6 +516,33 @@ public class DataStoreTest {
         client.getSyncManager().clear(Person.LONG_NAME);
         Person56 result = store.save(new Person56());
         assertNotNull(result);
+    }
+
+    @Test
+    public void testALotSymbolsInListName() throws InterruptedException, IOException {
+        DataStore<PersonLongListName> store = DataStore.collection(PersonLongListName.LONG_NAME, PersonLongListName.class, StoreType.SYNC, client);
+        assertNotNull(store);
+        client.getSyncManager().clear(PersonLongListName.LONG_NAME);
+        PersonLongListName person = new PersonLongListName();
+        List<String> list = new ArrayList<>();
+        list.add("Test1");
+        list.add("Test2");
+        person.setList(list);
+        PersonLongListName result = store.save(person);
+        assertNotNull(result);
+        result = store.find(client.query().equals(ID, result.getId())).get(0);
+        assertNotNull(result);
+        assertEquals(1, store.delete(result.getId()).longValue());
+    }
+
+    @Test
+    public void testOver63SymbolsInListName() throws InterruptedException, IOException {
+        try {
+            DataStore.collection(PersonOver63CharsInFieldName.LONG_NAME, PersonOver63CharsInFieldName.class, StoreType.SYNC, client);
+            assertFalse(true);
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e.getMessage().contains("Column names are currently limited to max 63 characters."));
+        }
     }
 
     @Test
@@ -2829,18 +2858,18 @@ public class DataStoreTest {
 
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(Person.COLLECTION, realm) + "_author", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(Person.COLLECTION, realm) + "_author", realm) + "__kmd", realm)).count(), 0);
-//            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(Person.COLLECTION, realm) + "_author", realm) + "__acl", realm)).count(), 0);
+            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(Person.COLLECTION, realm) + "_author", realm) + "__acl", realm)).count(), 0);
 
             assertEquals(realm.where(TableNameManagerUtil.getShortName("sync", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "_meta", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "_meta", realm) + "__kmd", realm)).count(), 0);
-//            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "_meta", realm) + "__acl", realm)).count(), 0);
+            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "_meta", realm) + "__acl", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "__kmd", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("sync", realm) + "__acl", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName("syncitems", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "_meta", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "_meta", realm) + "__kmd", realm)).count(), 0);
-//            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "_meta", realm) + "__acl", realm)).count(), 0);
+            assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "_meta", realm) + "__acl", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "__kmd", realm)).count(), 0);
             assertEquals(realm.where(TableNameManagerUtil.getShortName(TableNameManagerUtil.getShortName("syncitems", realm) + "__acl", realm)).count(), 0);
             realm.commitTransaction();

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -382,7 +382,7 @@ public abstract class ClassHash {
                 } else {
                     for (Class c : ALLOWED) {
                         if (underlying.equals(c)) {
-                            RealmObjectSchema innerScheme = realm.getSchema().create(shortName + "_" + fieldInfo.getName());
+                            RealmObjectSchema innerScheme = realm.getSchema().create(TableNameManager.createShortName(shortName + "_" + fieldInfo.getName(), realm));
                             if (!innerScheme.hasField(ID)){
                                 innerScheme.addField(ID, String.class, FieldAttribute.PRIMARY_KEY);
                             }
@@ -582,7 +582,7 @@ public abstract class ClassHash {
                     } else {
                         DynamicRealmObject dynamicRealmObject = null;
                         for (Object o : (Collection) collection) {
-                            dynamicRealmObject = realm.createObject(shortName + "_" + fieldInfo.getName(), UUID.randomUUID().toString());
+                            dynamicRealmObject = realm.createObject(TableNameManager.getShortName(shortName + "_" + fieldInfo.getName(), realm), UUID.randomUUID().toString());
 
                             for (Class c : ALLOWED) {
                                 if (underlying.equals(c)) {
@@ -695,7 +695,7 @@ public abstract class ClassHash {
             }
             if (fieldInfo.getType().isArray() || Collection.class.isAssignableFrom(fieldInfo.getType())) {
                 Class underlying = getUnderlying(f);
-                if (underlying != null && GenericJson.class.isAssignableFrom(underlying)) {
+                if (underlying != null) {
                     RealmList<DynamicRealmObject> list = realmObject.getList(fieldInfo.getName());
 
                     List<String> ids = new ArrayList<>();


### PR DESCRIPTION
#### Description
If ArrayList<String> field with the long name (more than 7 chars) is used in a data model class, SDK had the exception like "Class name is too long".

#### Changes
SDK creates the additional table with the short name for keeping Lists. Before this logic worked only for embedded objects.

#### Tests
Instrumented
