### PR TITLE
feat: MLIBZ-2185 Clear does not clear metadata for data synced in previous sdk versions

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -47,9 +47,9 @@ public class TestManager<T extends GenericJson> {
     public static final String PASSWORD = "test";
 
     public void login(final String userName, final String password, final Client client) throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        LooperThread looperThread = null;
         if (!client.isUserLoggedIn()) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            LooperThread looperThread = null;
             looperThread = new LooperThread(new Runnable() {
                 @Override
                 public void run() {
@@ -73,11 +73,7 @@ public class TestManager<T extends GenericJson> {
                 }
             });
             looperThread.start();
-        } else {
-            latch.countDown();
-        }
-        latch.await();
-        if (looperThread != null) {
+            latch.await();
             looperThread.mHandler.sendMessage(new Message());
         }
     }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheManagerTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheManagerTest.java
@@ -9,15 +9,20 @@ import android.test.suitebuilder.annotation.SmallTest;
 
 import com.kinvey.android.Client;
 import com.kinvey.android.cache.RealmCache;
-import com.kinvey.android.cache.RealmCacheManager;
+import com.kinvey.android.store.DataStore;
+import com.kinvey.androidTest.model.Person;
 import com.kinvey.java.KinveyException;
-import com.kinvey.java.cache.ICache;
 import com.kinvey.java.cache.ICacheManager;
+import com.kinvey.java.store.StoreType;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Prots on 1/27/16.
@@ -61,4 +66,13 @@ public class CacheManagerTest {
     public void getCacheShouldBeInstanceOfRealmCache(){
         assertTrue(manager.getCache("test", SampleGsonObject1.class, Long.MAX_VALUE) instanceof RealmCache);
     }
+
+    @Test
+    public void clearCollectionShouldNotFail() throws IOException, InterruptedException {
+        Client client = new Client.Builder(mMockContext).build();
+        DataStore dataStore = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        dataStore.clear();
+        client.performLockDown();
+    }
+
 }

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
@@ -195,7 +195,6 @@ public class RealmCacheManager implements ICacheManager {
      */
     private void removeSchemas(List<String> tableNames, DynamicRealm realm) {
         RealmSchema realmSchema = realm.getSchema();
-        System.out.println(tableNames);
         for (String tableName : tableNames) {
             if (realmSchema.get(tableName).hasPrimaryKey()) {
                 realmSchema.get(tableName).removePrimaryKey();

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCacheManager.java
@@ -195,6 +195,7 @@ public class RealmCacheManager implements ICacheManager {
      */
     private void removeSchemas(List<String> tableNames, DynamicRealm realm) {
         RealmSchema realmSchema = realm.getSchema();
+        System.out.println(tableNames);
         for (String tableName : tableNames) {
             if (realmSchema.get(tableName).hasPrimaryKey()) {
                 realmSchema.get(tableName).removePrimaryKey();
@@ -226,8 +227,9 @@ public class RealmCacheManager implements ICacheManager {
                 if (cache != null) {
                     cache.createRealmTable(realm);
                 }
-            } finally {
                 realm.commitTransaction();
+            } finally {
+                realm.close();
             }
         }
     }

--- a/java-api-core/src/com/kinvey/java/cache/ICacheManager.java
+++ b/java-api-core/src/com/kinvey/java/cache/ICacheManager.java
@@ -34,7 +34,12 @@ public interface ICacheManager {
     <T extends GenericJson> ICache<T> getCache(String collection, Class<T> collectionItemClass, Long ttl);
 
     /**
-     * clear all cached data
+     * Delete all collections
      */
     void clear();
+
+    /**
+     * Clear all cached data from the collection
+     */
+    <T extends GenericJson> void clearCollection(String collection, Class<T> collectionItemClass, Long ttl);
 }

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -315,7 +315,7 @@ public class BaseDataStore<T extends GenericJson> {
         Preconditions.checkArgument(storeType != StoreType.NETWORK, "InvalidDataStoreType");
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
-        client.getCacheManager().getCache(getCollectionName(), storeItemType, Long.MAX_VALUE).delete(new Query());
+        client.getCacheManager().clearCollection(getCollectionName(), storeItemType, Long.MAX_VALUE);
         purge();
     }
 


### PR DESCRIPTION
#### Description
`DataStore#clear` does not clear metadata for data synced in previous SDK versions.

#### Changes
Added new method `clearCollection` to CacheManager. The method deletes the collection and creates its new version. Current method `clear` just deletes realm file, this logic was saved. Logic for `DataStore.clear` was updated from `CacheManager#clear` to `CacheManager#clearCollection`.

#### Tests
Instrumented, Manual. Manual testing is necessary in this case because we have to update library version from 3.0.5 to latest version, it's impossible to check in the tests. Anyway, the small test for checking was added, the test checks that `CacheManager#clearCollection` doesn't crash.
