### PR TITLE
feat: MLIBZ-2430 Item isn't deleted from the backend after update delete operations with store type.sync

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -3254,6 +3254,7 @@ public class DataStoreTest {
         DefaultKinveyClientCallback callback = save(store, person);
         assertNotNull(callback.result);
         assertNotNull(callback.result.getUsername());
+        sync(store, DEFAULT_TIMEOUT);
 
         person = find(store, client.query().equals(Constants._ID, callback.result.getId()), DEFAULT_TIMEOUT).result.get(0);
         person.setUsername(TEST_USERNAME_2);
@@ -3268,6 +3269,7 @@ public class DataStoreTest {
         sync(store, DEFAULT_TIMEOUT);
 
         assertEquals(0, find(store, client.query().equals(Constants._ID, callback.result.getId()), DEFAULT_TIMEOUT).result.size());
+        assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
     }
 
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -3246,4 +3246,30 @@ public class DataStoreTest {
         assertEquals(0, updatedPersonWithoutList.getList().size());
     }
 
+    @Test
+    public void testCreateUpdateDeleteSync() throws InterruptedException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+        Person person = createPerson(TEST_USERNAME);
+        DefaultKinveyClientCallback callback = save(store, person);
+        assertNotNull(callback.result);
+        assertNotNull(callback.result.getUsername());
+
+        person = find(store, client.query().equals(Constants._ID, callback.result.getId()), DEFAULT_TIMEOUT).result.get(0);
+        person.setUsername(TEST_USERNAME_2);
+        callback = save(store, person);
+        assertNotNull(callback.result);
+        assertNotNull(callback.result.getUsername());
+        assertEquals(TEST_USERNAME_2, callback.result.getUsername());
+
+        DefaultKinveyDeleteCallback deleteCallback = delete(store, callback.result.getId(), DEFAULT_TIMEOUT);
+        assertNotNull(deleteCallback.result);
+
+        sync(store, DEFAULT_TIMEOUT);
+
+        assertEquals(0, find(store, client.query().equals(Constants._ID, callback.result.getId()), DEFAULT_TIMEOUT).result.size());
+    }
+
+
+
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -3272,6 +3272,24 @@ public class DataStoreTest {
         assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
     }
 
+    @Test
+    public void testCreateDeleteSync() throws InterruptedException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        client.getSyncManager().clear(Person.COLLECTION);
+        Person person = createPerson(TEST_USERNAME);
+        DefaultKinveyClientCallback callback = save(store, person);
+        assertNotNull(callback.result);
+        assertNotNull(callback.result.getUsername());
+
+        DefaultKinveyDeleteCallback deleteCallback = delete(store, callback.result.getId(), DEFAULT_TIMEOUT);
+        assertNotNull(deleteCallback.result);
+
+        sync(store, DEFAULT_TIMEOUT);
+
+        assertEquals(0, find(store, client.query().equals(Constants._ID, callback.result.getId()), DEFAULT_TIMEOUT).result.size());
+        assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
+    }
+
 
 
 }

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
@@ -23,6 +23,7 @@ import com.kinvey.android.AsyncClientRequest;
 import com.kinvey.android.sync.KinveyPushCallback;
 import com.kinvey.android.sync.KinveyPushResponse;
 import com.kinvey.java.AbstractClient;
+import com.kinvey.java.Constants;
 import com.kinvey.java.KinveyException;
 import com.kinvey.java.Query;
 import com.kinvey.java.network.NetworkManager;
@@ -129,8 +130,8 @@ public class AsyncPushRequest<T extends GenericJson> extends AsyncClientRequest<
                             t = client.getCacheManager().getCache(collection, storeItemType, Long.MAX_VALUE).get(id);
                             if (t == null) {
                                 // check that item wasn't deleted before
-//                            manager.deleteCachedItem((String) syncItem.get("_id"));
-                                manager.deleteCachedItems(new Query().equals("meta.id", syncItem.getEntityID().id));
+                                // if item wasn't found, it means that the item was deleted from the Cache by Delete request and the item will be deleted in case:DELETE
+                                manager.deleteCachedItems(client.query().equals("meta.id", syncItem.getEntityID().id).notEqual(Constants.REQUEST_METHOD, Constants.DELETE));
                                 continue;
                             }
                             syncRequest = manager.createSyncRequest(collection, networkManager.saveBlocking(t));

--- a/android-lib/src/main/java/com/kinvey/android/async/CallableAsyncPushRequestHelper.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/CallableAsyncPushRequestHelper.java
@@ -2,6 +2,7 @@ package com.kinvey.android.async;
 
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Constants;
+import com.kinvey.java.core.KinveyJsonResponseException;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncItem;
 import com.kinvey.java.sync.dto.SyncRequest;
@@ -10,7 +11,8 @@ import java.util.concurrent.Callable;
 
 public class CallableAsyncPushRequestHelper implements Callable {
 
-    private static final String IGNORED_EXCEPTION = "EntityNotFound";
+    private static final String IGNORED_EXCEPTION_MESSAGE = "EntityNotFound";
+    private static final int IGNORED_EXCEPTION_CODE = 404;
 
     private final AbstractClient client;
     private final SyncManager manager;
@@ -31,8 +33,8 @@ public class CallableAsyncPushRequestHelper implements Callable {
     public Long call() throws Exception {
         try {
             manager.executeRequest(client, syncRequest);
-        } catch (Exception e) {
-            if (!e.getMessage().contains(IGNORED_EXCEPTION)) {
+        } catch (KinveyJsonResponseException e) {
+            if (e.getStatusCode() != IGNORED_EXCEPTION_CODE && !e.getMessage().contains(IGNORED_EXCEPTION_MESSAGE)) {
                 throw e;
             }
         }

--- a/android-lib/src/main/java/com/kinvey/android/async/CallableAsyncPushRequestHelper.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/CallableAsyncPushRequestHelper.java
@@ -1,6 +1,7 @@
 package com.kinvey.android.async;
 
 import com.kinvey.java.AbstractClient;
+import com.kinvey.java.Constants;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncItem;
 import com.kinvey.java.sync.dto.SyncRequest;
@@ -8,6 +9,8 @@ import com.kinvey.java.sync.dto.SyncRequest;
 import java.util.concurrent.Callable;
 
 public class CallableAsyncPushRequestHelper implements Callable {
+
+    private static final String IGNORED_EXCEPTION = "EntityNotFound";
 
     private final AbstractClient client;
     private final SyncManager manager;
@@ -26,8 +29,14 @@ public class CallableAsyncPushRequestHelper implements Callable {
 
     @Override
     public Long call() throws Exception {
-        manager.executeRequest(client, syncRequest);
-        manager.deleteCachedItem((String) syncItem.get("_id"));
+        try {
+            manager.executeRequest(client, syncRequest);
+        } catch (Exception e) {
+            if (!e.getMessage().contains(IGNORED_EXCEPTION)) {
+                throw e;
+            }
+        }
+        manager.deleteCachedItem((String) syncItem.get(Constants._ID));
         return 1L;
     }
 }

--- a/java-api-core/src/com/kinvey/java/Constants.java
+++ b/java-api-core/src/com/kinvey/java/Constants.java
@@ -9,9 +9,13 @@ public final class Constants {
     public static final String UNDERSCORE = "_";
     public static final String TIME_FORMAT = "%tFT%<tTZ";
     public static final String Z = "Z";
+    public static final String DOT = ".";
+    public static final String QUERY = "query";
+    public static final String _ID = "_id";
+    public static final String DELETE = "DELETE";
+    public static final String REQUEST_METHOD = "requestMethod";
 
     public static final String CHAR_PERIOD = ".";
-    public static final String _ID = "_id";
     public static final String STR_LIVE_SERVICE_COLLECTION_CHANNEL_PREPEND = "c-";
 
     public static final String HYPHEN = "-";

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -35,6 +35,8 @@ import java.util.List;
  */
 public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteRequest<T> {
 
+    private static final String IGNORED_EXCEPTION = "EntityNotFound";
+
     private ICache<T> cache;
     private NetworkManager<T> networkManager;
     private final SyncManager syncManager;
@@ -77,8 +79,14 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
                             break;
                     }
                 }
-                syncManager.executeRequest(client, syncRequest);
-                syncManager.deleteCachedItem((String) syncItem.get("_id"));
+                try {
+                    syncManager.executeRequest(client, syncRequest);
+                } catch (Exception e) {
+                    if (!e.getMessage().contains(IGNORED_EXCEPTION)) {
+                        throw e;
+                    }
+                }
+                syncManager.deleteCachedItem((String) syncItem.get(Constants._ID));
             }
         }
         return null;

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -19,8 +19,8 @@ package com.kinvey.java.store.requests.data;
 import com.google.api.client.json.GenericJson;
 import com.kinvey.java.AbstractClient;
 import com.kinvey.java.Constants;
-import com.kinvey.java.Query;
 import com.kinvey.java.cache.ICache;
+import com.kinvey.java.core.KinveyJsonResponseException;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
@@ -35,7 +35,8 @@ import java.util.List;
  */
 public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteRequest<T> {
 
-    private static final String IGNORED_EXCEPTION = "EntityNotFound";
+    private static final String IGNORED_EXCEPTION_MESSAGE = "EntityNotFound";
+    private static final int IGNORED_EXCEPTION_CODE = 404;
 
     private ICache<T> cache;
     private NetworkManager<T> networkManager;
@@ -81,8 +82,8 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
                 }
                 try {
                     syncManager.executeRequest(client, syncRequest);
-                } catch (Exception e) {
-                    if (!e.getMessage().contains(IGNORED_EXCEPTION)) {
+                } catch (KinveyJsonResponseException e) {
+                    if (e.getStatusCode() != IGNORED_EXCEPTION_CODE && !e.getMessage().contains(IGNORED_EXCEPTION_MESSAGE)) {
                         throw e;
                     }
                 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -18,6 +18,7 @@ package com.kinvey.java.store.requests.data;
 
 import com.google.api.client.json.GenericJson;
 import com.kinvey.java.AbstractClient;
+import com.kinvey.java.Constants;
 import com.kinvey.java.Query;
 import com.kinvey.java.cache.ICache;
 import com.kinvey.java.network.NetworkManager;
@@ -66,7 +67,7 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
                             t = cache.get(syncItem.getEntityID().id);
                             if (t == null) {
                                 // check that item wasn't deleted before
-                                syncManager.deleteCachedItems(new Query().equals("meta.id", syncItem.getEntityID().id));
+                                syncManager.deleteCachedItems(client.query().equals("meta.id", syncItem.getEntityID().id).notEqual(Constants.REQUEST_METHOD, Constants.DELETE));
                                 continue;
                             }
                             syncRequest = syncManager.createSyncRequest(collection, networkManager.saveBlocking(cache.get(syncItem.getEntityID().id)));

--- a/java-api-core/src/com/kinvey/java/sync/SyncManager.java
+++ b/java-api-core/src/com/kinvey/java/sync/SyncManager.java
@@ -144,7 +144,10 @@ public class SyncManager {
         entityQuery.equals(META_DOT_ID, id);
         List<SyncItem> itemsList = requestCache.get(entityQuery);
 
-        if (itemsList.size() == 0 || method == RequestMethod.DELETE) {
+        if (itemsList.isEmpty()) {
+            requestCache.save(createSyncItem(collectionName, method, networkManager, id));
+        } else if (method == RequestMethod.DELETE) {
+            requestCache.delete(entityQuery);
             requestCache.save(createSyncItem(collectionName, method, networkManager, id));
         }
     }

--- a/java-api-core/src/com/kinvey/java/sync/SyncManager.java
+++ b/java-api-core/src/com/kinvey/java/sync/SyncManager.java
@@ -144,7 +144,7 @@ public class SyncManager {
         entityQuery.equals(META_DOT_ID, id);
         List<SyncItem> itemsList = requestCache.get(entityQuery);
 
-        if (itemsList.size() == 0) {
+        if (itemsList.size() == 0 || method == RequestMethod.DELETE) {
             requestCache.save(createSyncItem(collectionName, method, networkManager, id));
         }
     }


### PR DESCRIPTION
#### Description
Item isn't deleted from the backend after update delete operations with store type.sync.

Precondition: 
Create dataStore with StoreType.SYNC

Steps:
1. Create item (state1) and push it to the server 
2. Update item (state2)
3. Delete item
4. Sync with the server

Actual Result:
In the store we have the item (state1).
Expected result:
Item should be removed (from both the cache and the backend).

#### Changes
`DELETE` sync request will be added to a stack of sync requests even if `SAVE` request already exists in the stack.

#### Tests
Instrumented
