### PR TITLE
feat: MLIBZ-2414 Change how auto-pagination is enabled

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -323,6 +323,21 @@ public class TestManager<T extends GenericJson> {
         return callback;
     }
 
+    public CustomKinveySyncCallback<T> sync(final DataStore<T> store, final Query query, final int pageSize) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CustomKinveySyncCallback<T> callback = new CustomKinveySyncCallback<>(latch);
+        LooperThread looperThread = new LooperThread(new Runnable() {
+            @Override
+            public void run() {
+                store.sync(query, pageSize, callback);
+            }
+        });
+        looperThread.start();
+        latch.await();
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
+    }
+
     //cleaning backend store (can be improved)
     @Deprecated
     public void cleanBackendDataStore(DataStore<Person> store) throws InterruptedException {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -257,6 +257,25 @@ public class TestManager<T extends GenericJson> {
         return callback;
     }
 
+    public CustomKinveyPullCallback<T> pullCustom(final DataStore<T> store, final Query query, final int pageSize) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CustomKinveyPullCallback<T> callback = new CustomKinveyPullCallback<T>(latch);
+        LooperThread looperThread = new LooperThread(new Runnable() {
+            @Override
+            public void run() {
+                if (query != null) {
+                    store.pull(query, pageSize, callback);
+                } else {
+                    store.pull(pageSize, callback);
+                }
+            }
+        });
+        looperThread.start();
+        latch.await();
+        looperThread.mHandler.sendMessage(new Message());
+        return callback;
+    }
+
     public DefaultKinveyPushCallback push(final DataStore<Person> store) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final DefaultKinveyPushCallback callback = new DefaultKinveyPushCallback(latch);

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -329,7 +329,11 @@ public class TestManager<T extends GenericJson> {
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {
-                store.sync(query, pageSize, callback);
+                if (query != null) {
+                    store.sync(query, pageSize, callback);
+                } else {
+                    store.sync(pageSize, callback);
+                }
             }
         });
         looperThread.start();

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1447,7 +1447,6 @@ public class DataStoreTest {
         CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, null);
         assertTrue(pullCallback.getResult().getListOfExceptions().size() == 1);
         assertTrue(pullCallback.getResult().getResult().size() == 4);
-        testManager.cleanBackend(store, StoreType.SYNC);
     }
 
     @Test

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -1150,15 +1150,40 @@ public class DataStoreTest {
     public void testSyncPaged() throws InterruptedException, IOException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
         TestManager<Person> testManager = new TestManager<>();
+        testManager.cleanBackend(store, StoreType.SYNC);
         client.getSyncManager().clear(Person.COLLECTION);
         testManager.createPersons(store, 10);
         assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 10);
-        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, client.query(), 1);
+        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, null, 1);
         assertNull(syncCallback.getError());
         assertNotNull(syncCallback.getKinveyPushResponse().getSuccessCount());
-        assertNotNull(syncCallback.getKinveyPushResponse().getSuccessCount() == 0);
+        assertEquals(10, syncCallback.getKinveyPushResponse().getSuccessCount());
         assertNotNull(syncCallback.getResult());
+        assertEquals(0, syncCallback.getResult().getListOfExceptions().size());
+        assertNotNull(syncCallback.getResult().getResult());
+        assertEquals(10, syncCallback.getResult().getResult().size());
         assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+        assertEquals(10, store.find().size());
+    }
+
+    @Test
+    public void testSyncPagedWithQuery() throws InterruptedException, IOException {
+        DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        TestManager<Person> testManager = new TestManager<>();
+        testManager.cleanBackend(store, StoreType.SYNC);
+        client.getSyncManager().clear(Person.COLLECTION);
+        testManager.createPersons(store, 10);
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 10);
+        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, client.query().equals("username", TEST_USERNAME + 0).or(client.query().equals("username", TEST_USERNAME + 1)), 1);
+        assertNull(syncCallback.getError());
+        assertNotNull(syncCallback.getKinveyPushResponse().getSuccessCount());
+        assertEquals(10, syncCallback.getKinveyPushResponse().getSuccessCount());
+        assertNotNull(syncCallback.getResult());
+        assertEquals(0, syncCallback.getResult().getListOfExceptions().size());
+        assertNotNull(syncCallback.getResult().getResult());
+        assertEquals(2, syncCallback.getResult().getResult().size());
+        assertTrue(client.getSyncManager().getCount(Person.COLLECTION) == 0);
+        assertEquals(10, store.find().size());
     }
 
     @Test

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
@@ -33,8 +33,7 @@ public class AsyncPullRequest<T extends GenericJson> extends AsyncClientRequest<
 
     private final BaseDataStore<T> store;
     private Query query;
-    private int pageSize;
-    private boolean isAutoPagination = false;
+    private final int pageSize;
 
     /**
      * Async pull request constructor
@@ -48,6 +47,7 @@ public class AsyncPullRequest<T extends GenericJson> extends AsyncClientRequest<
         super(callback);
         this.query = query;
         this.store = store;
+        this.pageSize = 0;
     }
 
     /**
@@ -64,7 +64,6 @@ public class AsyncPullRequest<T extends GenericJson> extends AsyncClientRequest<
         super(callback);
         this.query = query;
         this.store = store;
-        this.isAutoPagination = true;
         this.pageSize = pageSize;
     }
 
@@ -73,7 +72,7 @@ public class AsyncPullRequest<T extends GenericJson> extends AsyncClientRequest<
     protected KinveyPullResponse<T> executeAsync() throws IOException, InvocationTargetException, IllegalAccessException {
         KinveyPullResponse<T> kinveyPullResponse = new KinveyPullResponse<>();
         KinveyAbstractReadResponse<T> pullResponse;
-        if (isAutoPagination) {
+        if (pageSize > 0) {
             pullResponse = store.pullBlocking(query, pageSize);
         } else {
             pullResponse = store.pullBlocking(query);

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
@@ -16,6 +16,7 @@
 
 package com.kinvey.android;
 
+import com.google.api.client.json.GenericJson;
 import com.kinvey.android.sync.KinveyPullCallback;
 import com.kinvey.android.sync.KinveyPullResponse;
 import com.kinvey.java.Query;
@@ -28,9 +29,12 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Class represents internal implementation of Async pull request that is used to create pull
  */
-public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T>> {
-    private final BaseDataStore store;
+public class AsyncPullRequest<T extends GenericJson> extends AsyncClientRequest<KinveyPullResponse<T>> {
+
+    private final BaseDataStore<T> store;
     private Query query;
+    private int pageSize;
+    private boolean isAutoPagination = false;
 
     /**
      * Async pull request constructor
@@ -38,19 +42,42 @@ public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T
      * @param store Kinvey data store instance to be used to execute network requests
      * @param callback async callbacks to be invoked when job is done
      */
-    public AsyncPullRequest(BaseDataStore store,
+    public AsyncPullRequest(BaseDataStore<T>  store,
                             Query query,
-                            KinveyPullCallback<T> callback){
+                            KinveyPullCallback<T> callback) {
         super(callback);
         this.query = query;
         this.store = store;
     }
 
+    /**
+     * Async pull request constructor
+     * @param query Query that is used to fetch data from network
+     * @param pageSize Page size for auto-pagination
+     * @param store Kinvey data store instance to be used to execute network requests
+     * @param callback async callbacks to be invoked when job is done
+     */
+    public AsyncPullRequest(BaseDataStore<T> store,
+                            Query query,
+                            int pageSize,
+                            KinveyPullCallback<T> callback) {
+        super(callback);
+        this.query = query;
+        this.store = store;
+        this.isAutoPagination = true;
+        this.pageSize = pageSize;
+    }
+
 
     @Override
     protected KinveyPullResponse<T> executeAsync() throws IOException, InvocationTargetException, IllegalAccessException {
-        KinveyPullResponse<T> kinveyPullResponse = new KinveyPullResponse<T>();
-        KinveyAbstractReadResponse<T> pullResponse = store.pullBlocking(query);
+        KinveyPullResponse<T> kinveyPullResponse = new KinveyPullResponse<>();
+        KinveyAbstractReadResponse<T> pullResponse;
+        if (isAutoPagination) {
+            pullResponse = store.pullBlocking(query, pageSize);
+        } else {
+            pullResponse = store.pullBlocking(query);
+        }
         kinveyPullResponse.setListOfExceptions(pullResponse.getListOfExceptions());
         kinveyPullResponse.setResult(pullResponse.getResult());
         return kinveyPullResponse;

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -85,7 +85,7 @@ import java.util.Map;
  * <p>
  * Methods in this API use either {@link KinveyListCallback} for retrieving entity sets,
  * {@link KinveyDeleteCallback} for deleting appData, or  the general-purpose
- * {@link KinveyClientCallback} used for retrieving single entites or saving Entities.
+ * {@link KinveyClientCallback} used for retrieving single entities or saving Entities.
  * </p>
  * <p/>
  * <p>
@@ -596,7 +596,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     }
 
     /**
-     * Asynchronous request to delete a collection of entites from a collection by Query.
+     * Asynchronous request to delete a collection of entities from a collection by Query.
      * <p>
      * Creates an asynchronous request to delete an entity from a  collection by Entity ID.  Uses KinveyDeleteCallback to return a
      * {@link com.kinvey.java.model.KinveyDeleteResponse}.
@@ -606,7 +606,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * <pre>
      * {@code
      *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
-     *     Query myQuery = new Query();
+     *     Query myQuery = client.query();
      *     myQuery.equals("age",21);
      *     myAppData.delete(myQuery, new KinveyDeleteCallback {
      *         public void onFailure(Throwable t) { ... }
@@ -628,9 +628,9 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     }
 
     /**
-     * Asynchronous request to push a collection of entites to backend.
+     * Asynchronous request to push a collection of entities to backend.
      * <p>
-     * Creates an asynchronous request to push a collection of entites.  Uses KinveyPushCallback to return a
+     * Creates an asynchronous request to push a collection of entities.  Uses KinveyPushCallback to return a
      * {@link KinveyPushResponse}.
      * </p>
      * <p>
@@ -655,7 +655,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     }
 
     /**
-     * Asynchronous request to pull a collection of entites from backend.
+     * Asynchronous request to pull a collection of entities from backend.
      * <p>
      * Creates an asynchronous request to pull an entity from backend.  Uses KinveyPullCallback<T> to return a
      * {@link KinveyPullResponse}.
@@ -665,7 +665,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * <pre>
      * {@code
      *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
-     *     Query myQuery = new Query();
+     *     Query myQuery = client.query();
      *     myQuery.equals("age",21);
      *     myAppData.pull(myQuery, new KinveyPullCallback {
      *         public void onFailure(Throwable t) { ... }
@@ -681,11 +681,11 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     public void pull(Query query, KinveyPullCallback<T> callback) {
         Preconditions.checkNotNull(client, "client must not be null");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
-        new AsyncPullRequest<T>(this, query, callback).execute();
+        new AsyncPullRequest<>(this, query, callback).execute();
     }
 
     /**
-     * Asynchronous request to pull a collection of entites from backend.
+     * Asynchronous request to pull a collection of entities from backend.
      * <p>
      * Creates an asynchronous request to pull all entity from backend.  Uses KinveyPullCallback<T> to return a
      * {@link KinveyPullResponse}.
@@ -707,6 +707,68 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      */
     public void pull(KinveyPullCallback<T> callback) {
         this.pull(null, callback);
+    }
+
+
+    /**
+     * Asynchronous request to pull a collection of entities from backend using auto-pagination.
+     * <p>
+     * Creates an asynchronous request to pull an entity from backend.  Uses KinveyPullCallback<T> to return a
+     * {@link KinveyPullResponse}.
+     * </p>
+     * <p>
+     * Sample Usage:
+     * <pre>
+     * {@code
+     *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
+     *     Query myQuery = client.query();
+     *     myQuery.equals("age", 21);
+     *     myAppData.pull(myQuery, 5000, new KinveyPullCallback {
+     *         public void onFailure(Throwable t) { ... }
+     *         public void onSuccess(KinveyPullResponse kinveyPullResponse) { ... }
+     *     });
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param query {@link Query} to filter the results.
+     * @param pageSize Page size for auto-pagination
+     * @param callback KinveyPullCallback
+     */
+    public void pull(Query query, int pageSize, KinveyPullCallback<T> callback) {
+        Preconditions.checkArgument(pageSize > 0, "pageSize must be more than 0");
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        new AsyncPullRequest<>(this, query, pageSize, callback).execute();
+    }
+
+    /**
+     * Asynchronous request to pull a collection of entities from backend using auto-pagination.
+     * <p>
+     * Creates an asynchronous request to pull all entity from backend.  Uses KinveyPullCallback<T> to return a
+     * {@link KinveyPullResponse}.
+     * </p>
+     * <p>
+     * Sample Usage:
+     * <pre>
+     * {@code
+     *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
+     *     myAppData.pull(5000, new KinveyPullCallback {
+     *         public void onFailure(Throwable t) { ... }
+     *         public void onSuccess(KinveyPullResponse kinveyPullResponse) { ... }
+     *     });
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param pageSize Page size for auto-pagination
+     * @param callback KinveyPullCallback
+     */
+    public void pull(int pageSize, KinveyPullCallback<T> callback) {
+        Preconditions.checkArgument(pageSize > 0, "pageSize must be more than 0");
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        this.pull(null, pageSize,  callback);
     }
 
     /**
@@ -749,7 +811,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
 
 
     /**
-     * Asynchronous request to sync a collection of entites from a network collection by Query.
+     * Asynchronous request to sync a collection of entities from a network collection by Query.
      * <p>
      * Creates an asynchronous request to sync local entities and network entries matched query from
      * a given collection by Query.  Uses KinveySyncCallback to return a
@@ -760,7 +822,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * <pre>
      * {@code
      *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
-     *     Query myQuery = new Query();
+     *     Query myQuery = client.query();
      *     myQuery.equals("age",21);
      *     myAppData.sync(myQuery, new KinveySyncCallback {
      *     public void onSuccess(KinveyPushResponse kinveyPushResponse,

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -843,6 +843,8 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * @param callback KinveyDeleteCallback
      */
     public void sync(final Query query, final KinveySyncCallback<T> callback) {
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized");
         callback.onPushStarted();
         push(new KinveyPushCallback() {
             @Override
@@ -879,12 +881,97 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     }
 
     /**
+     * Asynchronous request to sync a collection of entities from a network collection by Query.
+     * <p>
+     * Creates an asynchronous request to sync local entities and network entries matched query from
+     * a given collection by Query.  Uses KinveySyncCallback to return a
+     * {@link com.kinvey.android.sync.KinveySyncCallback}.
+     * </p>
+     * <p>
+     * Sample Usage:
+     * <pre>
+     * {@code
+     *     DataStore<EventEntity> myAppData = DataStore.collection("myCollection", EventEntity.class, StoreType.SYNC, myClient);
+     *     Query myQuery = client.query();
+     *     myQuery.equals("age",21);
+     *     myAppData.sync(myQuery, 5000, new KinveySyncCallback<> {
+     *     public void onSuccess(KinveyPushResponse kinveyPushResponse,
+     *         KinveyPullResponse<T> kinveyPullResponse) {...}
+     *         void onSuccess(){...};
+     *         void onPullStarted(){...};
+     *         void onPushStarted(){...};
+     *         void onPullSuccess(){...};
+     *         void onPushSuccess(){...};
+     *         void onFailure(Throwable t){...};
+     *
+     *     });
+     * }
+     * </pre>
+     * </p>
+     *
+     * @param query {@link Query} to filter the results or null if you don't want to query.
+     * @param pageSize Page size for auto-pagination
+     * @param callback KinveyDeleteCallback
+     */
+    public void sync(final Query query, final int pageSize, final KinveySyncCallback<T> callback) {
+        Preconditions.checkArgument(pageSize > 0, "pageSize must be more than 0");
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        callback.onPushStarted();
+        push(new KinveyPushCallback() {
+            @Override
+            public void onSuccess(final KinveyPushResponse pushResult) {
+                callback.onPushSuccess(pushResult);
+                callback.onPullStarted();
+                DataStore.this.pull(query, pageSize, new KinveyPullCallback<T>() {
+
+                    @Override
+                    public void onSuccess(KinveyPullResponse<T> pullResult) {
+                        callback.onPullSuccess(pullResult);
+                        callback.onSuccess(pushResult, pullResult);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable error) {
+                        callback.onFailure(error);
+
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(Throwable error) {
+                callback.onFailure(error);
+            }
+
+            @Override
+            public void onProgress(long current, long all) {
+
+            }
+        });
+    }
+
+    /**
      * Alias for {@link #sync(Query, KinveySyncCallback)} where query equals null
      *
      * @param callback callback to notify working thread on operation status update
      */
     public void sync(final KinveySyncCallback<T> callback) {
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized");
         sync(null, callback);
+    }
+
+    /**
+     * Alias for {@link #sync(Query, KinveySyncCallback)} where query equals null
+     *
+     * @param pageSize Page size for auto-pagination
+     * @param callback callback to notify working thread on operation status update
+     */
+    public void sync(final int pageSize, final KinveySyncCallback<T> callback) {
+        Preconditions.checkNotNull(client, "client must not be null");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized");
+        sync(null, pageSize, callback);
     }
 
     public Query query() {

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -414,6 +414,16 @@ public class BaseDataStore<T extends GenericJson> {
         pullBlocking(query);
     }
 
+    /**
+     * Run sync operation to sync local and network storages
+     * @param query query to pull the objects
+     * @param pageSize page size for auto-pagination
+     */
+    public void syncBlocking(Query query, int pageSize) throws IOException {
+        pushBlocking();
+        pullBlocking(query, pageSize);
+    }
+
     public void purge() {
         Preconditions.checkArgument(storeType != StoreType.NETWORK, "InvalidDataStoreType");
         Preconditions.checkNotNull(client, "client must not be null.");

--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -75,29 +75,6 @@ public class BaseDataStore<T extends GenericJson> {
     KinveyDataStoreLiveServiceCallback<T> liveServiceCallback;
 
     /**
-     * It is a parameter to enable the auto-pagination of data retrieval from the backend.
-     * When you use a Sync or Cache data store, if you have more than 10,000 entities, normally
-     * a developer would have to provide skip and limit modifiers to page through all the results.
-     * Setting this value to true will automatically fetch all the pages necessary.
-     * Default value is false.
-     */
-    private boolean autoPagination = false;
-
-    public boolean isAutoPaginationEnabled() {
-        return this.autoPagination;
-    }
-
-    public void setAutoPagination(boolean paginate) {
-        this.autoPagination = paginate;
-    }
-
-    private int pageSize = 10000; // default page size set to backend record retrieval limit
-
-    public void setAutoPaginationPageSize(int size) {
-        pageSize = size;
-    }
-
-    /**
      * Constructor for creating BaseDataStore for given collection that will be mapped to itemType class
      * @param client Kinvey client instance to work with
      * @param collection collection name
@@ -390,39 +367,41 @@ public class BaseDataStore<T extends GenericJson> {
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
         Preconditions.checkArgument(client.getSyncManager().getCount(getCollectionName()) == 0, "InvalidOperation. You must push all pending sync items before new data is pulled. Call push() on the data store instance to push pending items, or purge() to remove them.");
-
-        KinveyAbstractReadResponse<T> response = new KinveyAbstractReadResponse<T>();
         query = query == null ? client.query() : query;
+        KinveyAbstractReadResponse<T> response = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
+        cache.delete(query);
+        cache.save(response.getResult());
+        return response;
+    }
 
-        if (isAutoPaginationEnabled()) {
-            if (query.getSortString() == null || query.getSortString().isEmpty()) {
-                query.addSort(Constants._ID, AbstractQuery.SortOrder.ASC);
-            }
-            List<T> networkData = new ArrayList<T>();
-            List<Exception> exceptions = new ArrayList<Exception>();
-            int skipCount = 0;
-            int pageSize = this.pageSize;
-
-            // First, get the count of all the items to pull
-            int totalItemCount = this.countNetwork();
-            KinveyAbstractReadResponse<T> pullResponse;
-            do {
-                query.setSkip(skipCount).setLimit(pageSize);
-                pullResponse = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
-                networkData.addAll(pullResponse.getResult());
-                exceptions.addAll(pullResponse.getListOfExceptions());
-                cache.delete(query);
-                cache.save(networkData);
-                skipCount += pageSize;
-            } while (skipCount < totalItemCount);
-            response.setResult(networkData);
-            response.setListOfExceptions(exceptions);
-        } else {
-            response = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
-            cache.delete(query);
-            cache.save(response.getResult());
+    public KinveyAbstractReadResponse<T> pullBlocking(Query query, int pageSize) throws IOException {
+        Preconditions.checkArgument(pageSize > 0, "pageSize must be more than 0");
+        Preconditions.checkArgument(storeType != StoreType.NETWORK, "InvalidDataStoreType");
+        Preconditions.checkNotNull(client, "client must not be null.");
+        Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
+        Preconditions.checkArgument(client.getSyncManager().getCount(getCollectionName()) == 0, "InvalidOperation. You must push all pending sync items before new data is pulled. Call push() on the data store instance to push pending items, or purge() to remove them.");
+        KinveyAbstractReadResponse<T> response = new KinveyAbstractReadResponse<>();
+        query = query == null ? client.query() : query;
+        if (query.getSortString() == null || query.getSortString().isEmpty()) {
+            query.addSort(Constants._ID, AbstractQuery.SortOrder.ASC);
         }
-
+        List<T> networkData = new ArrayList<>();
+        List<Exception> exceptions = new ArrayList<>();
+        int skipCount = 0;
+        // First, get the count of all the items to pull
+        int totalItemCount = this.countNetwork();
+        KinveyAbstractReadResponse<T> pullResponse;
+        do {
+            query.setSkip(skipCount).setLimit(pageSize);
+            pullResponse = networkManager.pullBlocking(query, cache, isDeltaSetCachingEnabled()).execute();
+            networkData.addAll(pullResponse.getResult());
+            exceptions.addAll(pullResponse.getListOfExceptions());
+            cache.delete(query);
+            cache.save(networkData);
+            skipCount += pageSize;
+        } while (skipCount < totalItemCount);
+        response.setResult(networkData);
+        response.setListOfExceptions(exceptions);
         return response;
     }
 


### PR DESCRIPTION
#### Description
Change how auto-pagination is enabled: from `dataStore.setAutoPagination(true);` to `pull(query, pageSize, callback);`.

#### Changes
Removed the isAutoPaginationEnabled boolen field from BaseDataStore.
Added new methods: `pullBlocking(Query query, int pageSize)` to the BaseDataStore and 
`pull(int pageSize, KinveyPullCallback<T> callback)`,  `pull(Query query, int pageSize, KinveyPullCallback<T> callback)`  to the DataStore classes.
Updated tests.

#### Tests
Instrumented.
