### PR TITLE
feat: MLIBZ-2387 Update auto pagination to meet design spec

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -238,9 +238,9 @@ public class TestManager<T extends GenericJson> {
         return callback;
     }
 
-    public CustomKinveyPullCallback<T> pullCustom(final DataStore<T> store, final Query query) throws InterruptedException {
+    public CustomKinveyPullCallback pullCustom(final DataStore<T> store, final Query query) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final CustomKinveyPullCallback<T> callback = new CustomKinveyPullCallback<T>(latch);
+        final CustomKinveyPullCallback callback = new CustomKinveyPullCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/TestManager.java
@@ -289,9 +289,9 @@ public class TestManager<T extends GenericJson> {
         return callback;
     }
 
-    public CustomKinveySyncCallback<T> sync(final DataStore<T> store, final Query query) throws InterruptedException {
+    public CustomKinveySyncCallback sync(final DataStore<T> store, final Query query) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
-        final CustomKinveySyncCallback<T> callback = new CustomKinveySyncCallback<T>(latch);
+        final CustomKinveySyncCallback callback = new CustomKinveySyncCallback(latch);
         LooperThread looperThread = new LooperThread(new Runnable() {
             @Override
             public void run() {

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveyPullCallback.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveyPullCallback.java
@@ -1,7 +1,7 @@
 package com.kinvey.androidTest.callback;
 
 import com.kinvey.android.sync.KinveyPullCallback;
-import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.model.KinveyPullResponse;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -9,10 +9,10 @@ import java.util.concurrent.CountDownLatch;
  * Created by yuliya on 09/14/17.
  */
 
-public class CustomKinveyPullCallback<T> implements KinveyPullCallback<T> {
+public class CustomKinveyPullCallback implements KinveyPullCallback {
 
     private CountDownLatch latch;
-    private KinveyPullResponse<T> result;
+    private KinveyPullResponse result;
     private Throwable error;
 
     public CustomKinveyPullCallback(CountDownLatch latch) {
@@ -20,7 +20,7 @@ public class CustomKinveyPullCallback<T> implements KinveyPullCallback<T> {
     }
 
     @Override
-    public void onSuccess(KinveyPullResponse<T> result) {
+    public void onSuccess(KinveyPullResponse result) {
         this.result = result;
         finish();
     }
@@ -35,7 +35,7 @@ public class CustomKinveyPullCallback<T> implements KinveyPullCallback<T> {
         latch.countDown();
     }
 
-    public KinveyPullResponse<T> getResult() {
+    public KinveyPullResponse getResult() {
         return result;
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveySyncCallback.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveySyncCallback.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CountDownLatch;
  * Created by yuliya on 12/27/17.
  */
 
-public class CustomKinveySyncCallback<T extends GenericJson> implements KinveySyncCallback<T> {
+public class CustomKinveySyncCallback implements KinveySyncCallback {
 
     private CountDownLatch latch;
     private KinveyPullResponse result;

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveySyncCallback.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/callback/CustomKinveySyncCallback.java
@@ -1,7 +1,7 @@
 package com.kinvey.androidTest.callback;
 
 import com.google.api.client.json.GenericJson;
-import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.model.KinveyPullResponse;
 import com.kinvey.android.sync.KinveyPushResponse;
 import com.kinvey.android.sync.KinveySyncCallback;
 
@@ -14,7 +14,7 @@ import java.util.concurrent.CountDownLatch;
 public class CustomKinveySyncCallback<T extends GenericJson> implements KinveySyncCallback<T> {
 
     private CountDownLatch latch;
-    private KinveyPullResponse<T> result;
+    private KinveyPullResponse result;
     private KinveyPushResponse kinveyPushResponse;
     private Throwable error;
     public CustomKinveySyncCallback(CountDownLatch latch) {
@@ -22,7 +22,7 @@ public class CustomKinveySyncCallback<T extends GenericJson> implements KinveySy
     }
 
     @Override
-    public void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse<T> kinveyPullResponse) {
+    public void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse kinveyPullResponse) {
         this.result = kinveyPullResponse;
         this.kinveyPushResponse = kinveyPushResponse;
         finish();
@@ -39,7 +39,7 @@ public class CustomKinveySyncCallback<T extends GenericJson> implements KinveySy
     }
 
     @Override
-    public void onPullSuccess(KinveyPullResponse<T> kinveyPullResponse) {
+    public void onPullSuccess(KinveyPullResponse kinveyPullResponse) {
 
     }
 
@@ -58,11 +58,11 @@ public class CustomKinveySyncCallback<T extends GenericJson> implements KinveySy
         latch.countDown();
     }
 
-    public KinveyPullResponse<T> getResult() {
+    public KinveyPullResponse getResult() {
         return result;
     }
 
-    public void setResult(KinveyPullResponse<T> result) {
+    public void setResult(KinveyPullResponse result) {
         this.result = result;
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -193,7 +193,7 @@ public class DataStoreTest {
         }
     }
 
-    private static class DefaultKinveySyncCallback implements KinveySyncCallback<Person> {
+    private static class DefaultKinveySyncCallback implements KinveySyncCallback {
 
         private CountDownLatch latch;
         KinveyPushResponse kinveyPushResponse;

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -21,7 +21,7 @@ import com.kinvey.android.model.User;
 import com.kinvey.android.store.DataStore;
 import com.kinvey.android.store.UserStore;
 import com.kinvey.android.sync.KinveyPullCallback;
-import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.model.KinveyPullResponse;
 import com.kinvey.android.sync.KinveyPushCallback;
 import com.kinvey.android.sync.KinveyPushResponse;
 import com.kinvey.android.sync.KinveySyncCallback;
@@ -197,7 +197,7 @@ public class DataStoreTest {
 
         private CountDownLatch latch;
         KinveyPushResponse kinveyPushResponse;
-        KinveyPullResponse<Person> kinveyPullResponse;
+        KinveyPullResponse kinveyPullResponse;
         Throwable error;
 
         DefaultKinveySyncCallback(CountDownLatch latch) {
@@ -205,7 +205,7 @@ public class DataStoreTest {
         }
 
         @Override
-        public void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse<Person> kinveyPullResponse) {
+        public void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse kinveyPullResponse) {
             this.kinveyPushResponse = kinveyPushResponse;
             this.kinveyPullResponse = kinveyPullResponse;
             finish();
@@ -224,7 +224,7 @@ public class DataStoreTest {
         }
 
         @Override
-        public void onPullSuccess(KinveyPullResponse<Person> kinveyPullResponse) {
+        public void onPullSuccess(KinveyPullResponse kinveyPullResponse) {
             this.kinveyPullResponse = kinveyPullResponse;
         }
 
@@ -276,10 +276,10 @@ public class DataStoreTest {
         }
     }
 
-    private static class DefaultKinveyPullCallback implements KinveyPullCallback<Person> {
+    private static class DefaultKinveyPullCallback implements KinveyPullCallback {
 
         private CountDownLatch latch;
-        KinveyPullResponse<Person> result;
+        KinveyPullResponse result;
         Throwable error;
 
         DefaultKinveyPullCallback(CountDownLatch latch) {
@@ -287,7 +287,7 @@ public class DataStoreTest {
         }
 
         @Override
-        public void onSuccess(KinveyPullResponse<Person> result) {
+        public void onSuccess(KinveyPullResponse result) {
             this.result = result;
             finish();
         }
@@ -1425,9 +1425,9 @@ public class DataStoreTest {
         TestManager<Person> testManager = new TestManager<>();
         testManager.login(TestManager.USERNAME, TestManager.PASSWORD, client);
         DataStore<Person> store = DataStore.collection(Person.COLLECTION_WITH_EXCEPTION, Person.class, StoreType.SYNC, client);
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, null);
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, null);
         assertTrue(pullCallback.getResult().getListOfExceptions().size() == 1);
-        assertTrue(pullCallback.getResult().getResult().size() == 4);
+        assertTrue(pullCallback.getResult().getCount() == 4);
         testManager.cleanBackendDataStore(store);
     }
 
@@ -1438,9 +1438,9 @@ public class DataStoreTest {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION_WITH_EXCEPTION, Person.class, StoreType.SYNC, client);
         store.setAutoPagination(true);
         store.setAutoPaginationPageSize(2);
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, null);
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, null);
         assertTrue(pullCallback.getResult().getListOfExceptions().size() == 1);
-        assertTrue(pullCallback.getResult().getResult().size() == 4);
+        assertTrue(pullCallback.getResult().getCount() == 4);
         testManager.cleanBackendDataStore(store);
     }
 
@@ -1474,8 +1474,8 @@ public class DataStoreTest {
         DefaultKinveyPullCallback pullCallback = pull(store, null);
         assertNull(pullCallback.error);
         assertNotNull(pullCallback.result);
-        assertTrue(pullCallback.result.getResult().size() == 3);
-        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.CACHE));
+        assertTrue(pullCallback.result.getCount() == 3);
+        assertTrue(pullCallback.result.getCount() == getCacheSize(StoreType.CACHE));
 
         //cleaning cache store
         client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.CACHE.ttl).clear();
@@ -1486,9 +1486,8 @@ public class DataStoreTest {
         pullCallback = pull(store, query);
         assertNull(pullCallback.error);
         assertNotNull(pullCallback.result);
-        assertTrue(pullCallback.result.getResult().size() == 1);
-        assertTrue(pullCallback.result.getResult().get(0).getUsername().equals(victor.getUsername()));
-        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.SYNC));
+        assertTrue(pullCallback.result.getCount() == 1);
+        assertTrue(pullCallback.result.getCount() == getCacheSize(StoreType.SYNC));
 
         cleanBackendDataStore(store);
 
@@ -1506,8 +1505,8 @@ public class DataStoreTest {
         pullCallback = pull(store, query);
         assertNull(pullCallback.error);
         assertNotNull(pullCallback.result);
-        assertTrue(pullCallback.result.getResult().size() == 0);
-        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.SYNC));
+        assertTrue(pullCallback.result.getCount() == 0);
+        assertTrue(pullCallback.result.getCount() == getCacheSize(StoreType.SYNC));
 
         cleanBackendDataStore(store);
 
@@ -1526,9 +1525,8 @@ public class DataStoreTest {
         pullCallback = pull(store, query);
         assertNull(pullCallback.error);
         assertNotNull(pullCallback.result);
-        assertTrue(pullCallback.result.getResult().size() == 1);
-        assertTrue(pullCallback.result.getResult().get(0).getUsername().equals(victor.getUsername()));
-        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.CACHE));
+        assertTrue(pullCallback.result.getCount() == 1);
+        assertTrue(pullCallback.result.getCount() == getCacheSize(StoreType.CACHE));
     }
 
     @Test
@@ -1570,8 +1568,8 @@ public class DataStoreTest {
         // Assert
         assertNull(pullCallback.error);
         assertNotNull(pullCallback.result);
-        assertTrue(pullCallback.result.getResult().size() == 3);
-        assertTrue(pullCallback.result.getResult().size() == getCacheSize(StoreType.CACHE));
+        assertTrue(pullCallback.result.getCount() == 3);
+        assertTrue(pullCallback.result.getCount() == getCacheSize(StoreType.CACHE));
     }
 
     @Test
@@ -1598,12 +1596,9 @@ public class DataStoreTest {
         // Act
         store.setAutoPagination(true);
         store.setAutoPaginationPageSize(2);
-        List<Person> pullResults = store.pullBlocking(null).getResult();
-
-        // Assert
-        assertNotNull(pullResults);
-        assertTrue(pullResults.size() == 3);
-        assertTrue(pullResults.size() == getCacheSize(StoreType.CACHE));
+        KinveyPullResponse pullResponse = store.pullBlocking(null);
+        assertEquals(3, pullResponse.getCount());
+        assertTrue(pullResponse.getCount() == getCacheSize(StoreType.CACHE));
     }
 
     @Test
@@ -1631,25 +1626,18 @@ public class DataStoreTest {
         long cacheSizeBetween = getCacheSize(StoreType.CACHE);
         assertTrue(cacheSizeBetween == 0);
 
-        List<Person> pullResults = null;
         Query query = client.query().addSort(SORT_FIELD, AbstractQuery.SortOrder.ASC);
         for (int i = 0; i < 5; i++) {
             query.setLimit(1);
             query.setSkip(i);
-            pullResults = store.pullBlocking(query).getResult();
-
-            assertNotNull(pullResults);
-            assertTrue(pullResults.size() == 1);
+            assertEquals(1, store.pullBlocking(query).getCount());
             assertEquals(i+1, getCacheSize(StoreType.CACHE));
         }
         assertEquals(5, getCacheSize(StoreType.CACHE));
         for (int i = 0; i < 5; i++) {
             query.setLimit(1);
             query.setSkip(i);
-            pullResults = store.pullBlocking(query).getResult();
-
-            assertNotNull(pullResults);
-            assertTrue(pullResults.size() == 1);
+            assertEquals(1, store.pullBlocking(query).getCount());
             assertEquals(5, getCacheSize(StoreType.CACHE));
         }
         assertEquals(5, getCacheSize(StoreType.CACHE));
@@ -1680,25 +1668,23 @@ public class DataStoreTest {
         long cacheSizeBetween = getCacheSize(StoreType.CACHE);
         assertTrue(cacheSizeBetween == 0);
 
-        List<Person> pullResults = null;
+        int resultCount = 0;
         Query query = client.query().addSort(ID, AbstractQuery.SortOrder.ASC);
         for (int i = 0; i < 5; i++) {
             query.setLimit(1);
             query.setSkip(i);
-            pullResults = pull(store, query).result.getResult();
+            resultCount = pull(store, query).result.getCount();
 
-            assertNotNull(pullResults);
-            assertTrue(pullResults.size() == 1);
+            assertEquals(1, resultCount);
             assertEquals(i+1, getCacheSize(StoreType.CACHE));
         }
         assertEquals(5, getCacheSize(StoreType.CACHE));
         for (int i = 0; i < 5; i++) {
             query.setLimit(1);
             query.setSkip(i);
-            pullResults = pull(store, query).result.getResult();
+            resultCount = pull(store, query).result.getCount();
 
-            assertNotNull(pullResults);
-            assertTrue(pullResults.size() == 1);
+            assertEquals(1, resultCount);
             assertEquals(5, getCacheSize(StoreType.CACHE));
         }
         assertEquals(5, getCacheSize(StoreType.CACHE));
@@ -1721,14 +1707,11 @@ public class DataStoreTest {
         sync(store, DEFAULT_TIMEOUT);
         client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.SYNC.ttl).clear();
 
-        List<Person> pullResults;
         Query query = client.query().addSort(ID, AbstractQuery.SortOrder.ASC);
         query.setLimit(1);
         for (int i = 0; i < 5; i++) {
             query.setSkip(i);
-            pullResults = pull(store, query).result.getResult();
-            assertNotNull(pullResults);
-            assertTrue(pullResults.size() == 1);
+            assertEquals(1, pull(store, query).result.getCount());
             assertEquals(i+1, getCacheSize(StoreType.SYNC));
         }
         assertEquals(5, getCacheSize(StoreType.SYNC));
@@ -1738,7 +1721,7 @@ public class DataStoreTest {
     public void testPullOrderWithSkipLimitQueryWithCachedItemsBeforeTestSortById() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
         client.getSyncManager().clear(Person.COLLECTION);
-        List<Person> pullResults;
+        DefaultKinveyPullCallback pullResponse;
         for (int j = 0; j < 10; j++) {
             cleanBackendDataStore(store);
             for (int i = 0; i < 5; i++) {
@@ -1749,9 +1732,9 @@ public class DataStoreTest {
             query.setLimit(1).addSort(ID, AbstractQuery.SortOrder.ASC);
             for (int i = 0; i < 5; i++) {
                 query.setSkip(i);
-                pullResults = pull(store, query).result.getResult();
-                assertNotNull(pullResults);
-                assertTrue(pullResults.size() == 1);
+                pullResponse = pull(store, query);
+                assertNotNull(pullResponse);
+                assertTrue(pullResponse.result.getCount() == 1);
                 assertEquals(5, getCacheSize(StoreType.SYNC));
             }
             System.out.println("TEST: number - " + j);
@@ -1764,7 +1747,7 @@ public class DataStoreTest {
     public void testPullOrderWithSkipLimitQueryWithCachedItemsBeforeTest() throws InterruptedException {
         DataStore<Person> store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
         client.getSyncManager().clear(Person.COLLECTION);
-        List<Person> pullResults;
+        KinveyPullResponse pullResponse;
         for (int j = 0; j < 10; j++) {
             cleanBackendDataStore(store);
             for (int i = 0; i < 5; i++) {
@@ -1775,9 +1758,9 @@ public class DataStoreTest {
             query.setLimit(1).addSort(ID, AbstractQuery.SortOrder.ASC);
             for (int i = 0; i < 5; i++) {
                 query.setSkip(i);
-                pullResults = pull(store, query).result.getResult();
-                assertNotNull(pullResults);
-                assertTrue(pullResults.size() == 1);
+                pullResponse = pull(store, query).result;
+                assertNotNull(pullResponse);
+                assertTrue(pullResponse.getCount() == 1);
                 assertEquals(5, getCacheSize(StoreType.SYNC));
             }
             System.out.println("TEST: number - " + j);
@@ -1791,7 +1774,7 @@ public class DataStoreTest {
         client.getSyncManager().clear(Person.COLLECTION);
         store.setAutoPagination(true);
         store.setAutoPaginationPageSize(1);
-        List<Person> pullResults;
+        KinveyPullResponse pullResponse;
         for (int j = 0; j < 10; j++) {
             cleanBackendDataStore(store);
             for (int i = 0; i < 5; i++) {
@@ -1799,8 +1782,8 @@ public class DataStoreTest {
             }
             sync(store, DEFAULT_TIMEOUT);
             Query query = client.query();
-            pullResults = pull(store, query).result.getResult();
-            assertNotNull(pullResults);
+            pullResponse = pull(store, query).result;
+            assertNotNull(pullResponse);
             assertEquals(5, getCacheSize(StoreType.SYNC));
         }
     }
@@ -1850,12 +1833,13 @@ public class DataStoreTest {
         client.getCacheManager().getCache(Person.COLLECTION, Person.class, StoreType.SYNC.ttl).clear();
 
         List<Person> pullResults;
+        int resultCount;
         Query query = client.query().addSort(ID, AbstractQuery.SortOrder.ASC);
         query.setLimit(1);
         for (int i = 0; i < 5; i++) {
             query.setSkip(i);
-            pullResults = pull(store, query).result.getResult();
-            assertNotNull(pullResults);
+            resultCount = pull(store, query).result.getCount();
+            assertNotNull(resultCount);
         }
         assertEquals(5, getCacheSize(StoreType.SYNC));
         findResult = find(store, client.query(), DEFAULT_TIMEOUT).result;
@@ -1871,8 +1855,8 @@ public class DataStoreTest {
         for (int i = 0; i < 5; i++) {
             query.setSkip(skip);
             skip += limit;
-            pullResults = pull(store, query).result.getResult();
-            assertNotNull(pullResults);
+            resultCount = pull(store, query).result.getCount();
+            assertNotNull(resultCount);
         }
         assertEquals(5, getCacheSize(StoreType.SYNC));
         findResult = find(store, client.query(), DEFAULT_TIMEOUT).result;
@@ -2097,10 +2081,7 @@ public class DataStoreTest {
             DefaultKinveyPullCallback pullCallback = pull(store, query);
             assertNull(pullCallback.error);
             assertNotNull(pullCallback.result);
-            assertTrue(pullCallback.result.getResult().size() == limit);
-            assertNotNull(pullCallback.result.getResult().get(0));
-            assertEquals(pullCallback.result.getResult().get(0).getUsername(), "Person_" + skip);
-            assertEquals(pullCallback.result.getResult().get(pullCallback.result.getResult().size()-1).getUsername(), "Person_" + (skip+1));
+            assertTrue(pullCallback.result.getCount() == limit);
             skip += limit;
         }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaCacheTest.java
@@ -54,7 +54,7 @@ public class DeltaCacheTest {
     public void setUp() throws InterruptedException, IOException {
         Context mMockContext = new RenamingDelegatingContext(InstrumentationRegistry.getInstrumentation().getTargetContext(), "test_");
         client = new Client.Builder(mMockContext).build();
-        testManager = new TestManager<Person>();
+        testManager = new TestManager<>();
         testManager.login(USERNAME, PASSWORD, client);
 
     }
@@ -88,12 +88,12 @@ public class DeltaCacheTest {
         assertNotNull(callback.getResult().getUsername());
         assertEquals(TEST_USERNAME, callback.getResult().getUsername());
 
-        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, client.query());
+        CustomKinveySyncCallback syncCallback = testManager.sync(store, client.query());
         assertNotNull(syncCallback);
         assertNotNull(syncCallback.getResult());
         assertNull(syncCallback.getError());
-        assertNotNull(syncCallback.getResult().getResult().get(0).getUsername());
-        assertEquals(TEST_USERNAME, syncCallback.getResult().getResult().get(0).getUsername());
+        assertNotNull(syncCallback.getResult().getCount());
+        assertEquals(1, syncCallback.getResult().getCount());
     }
 
     @Test
@@ -111,9 +111,10 @@ public class DeltaCacheTest {
         assertEquals(TEST_USERNAME, savedPerson.getUsername());
 
         store.pushBlocking();
-        Person downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
-        assertNotNull(downloadedPerson);
-        assertEquals(TEST_USERNAME, downloadedPerson.getUsername());
+        assertEquals(1, store.pullBlocking(client.query()).getCount());
+        
+        assertNotNull(store.find().get(0));
+        assertEquals(TEST_USERNAME, store.find().get(0).getUsername());
     }
 
     @Test
@@ -131,9 +132,9 @@ public class DeltaCacheTest {
         assertEquals(TEST_USERNAME, savedPerson.getUsername());
 
         store.pushBlocking();
-        Person downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
-        assertNotNull(downloadedPerson);
-        assertEquals(TEST_USERNAME, downloadedPerson.getUsername());
+        assertEquals(1, store.pullBlocking(client.query()).getCount());
+        assertNotNull(store.find().get(0));
+        assertEquals(TEST_USERNAME, store.find().get(0).getUsername());
 
         List<Person> personList = testManager.find(store, client.query()).getResult();
         Person person1 = personList.get(0);
@@ -153,9 +154,9 @@ public class DeltaCacheTest {
 
         store.pushBlocking();
         Query query = client.query().addSort("_kmd.ect", AbstractQuery.SortOrder.ASC);
-        List<Person> pulledPersons = store.pullBlocking(query).getResult();
+        assertEquals(TEN_ITEMS, store.pullBlocking(query).getCount());
+        List<Person> pulledPersons = store.find(query);
         assertNotNull(pulledPersons);
-        assertEquals(TEN_ITEMS, pulledPersons.size());
 
         Person person;
         for (int i = 0; i < TEN_ITEMS; i++) {
@@ -163,9 +164,8 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        pulledPersons = store.pullBlocking(query).getResult();
-        assertNotNull(pulledPersons);
-        assertEquals(TEN_ITEMS, pulledPersons.size());
+        assertEquals(TEN_ITEMS, store.pullBlocking(query).getCount());
+        pulledPersons = store.find(query);
 
         for (int i = 0; i < TEN_ITEMS; i++) {
             person = pulledPersons.get(i);
@@ -195,9 +195,9 @@ public class DeltaCacheTest {
         store.clear();
 
         Query query = client.query().addSort("_kmd.ect", AbstractQuery.SortOrder.ASC);
-        List<Person> pulledPersons = store.pullBlocking(query).getResult();
+        assertEquals(TEN_ITEMS, store.pullBlocking(query).getCount());
+        List<Person> pulledPersons = store.find(query);
         assertNotNull(pulledPersons);
-        assertEquals(TEN_ITEMS, pulledPersons.size());
 
         Person person;
         for (int i = 0; i < TEN_ITEMS; i++) {
@@ -205,9 +205,9 @@ public class DeltaCacheTest {
             assertEquals(TEST_USERNAME + i, person.getUsername());
         }
 
-        pulledPersons = store.pullBlocking(query).getResult();
+        assertEquals(TEN_ITEMS, store.pullBlocking(query).getCount());
+        pulledPersons = store.find(query);
         assertNotNull(pulledPersons);
-        assertEquals(TEN_ITEMS, pulledPersons.size());
 
         for (int i = 0; i < TEN_ITEMS; i++) {
             person = pulledPersons.get(i);
@@ -244,9 +244,11 @@ public class DeltaCacheTest {
         }
 
         store.pushBlocking();
-        List<Person> pulledPersons = store.pullBlocking(client.query().equals("age", "30").addSort("_kmd.ect", AbstractQuery.SortOrder.ASC)).getResult();
+        Query query = client.query().equals("age", "30").addSort("_kmd.ect", AbstractQuery.SortOrder.ASC);
+
+        assertEquals(TEN_ITEMS, store.pullBlocking(query).getCount());
+        List<Person> pulledPersons = store.find(query);
         assertNotNull(pulledPersons);
-        assertEquals(TEN_ITEMS, pulledPersons.size());
 
         Person person;
         for (int i = 0; i < TEN_ITEMS; i++) {
@@ -254,7 +256,7 @@ public class DeltaCacheTest {
             assertEquals("DeltaCacheUserNameQuery_" + i, person.getUsername());
         }
 
-        List<Person> foundPersons = testManager.find(store, client.query().equals("age", "30").addSort("_kmd.ect", AbstractQuery.SortOrder.ASC)).getResult();
+        List<Person> foundPersons = testManager.find(store, query).getResult();
 
         Person person1;
         for (int i = 0; i < TEN_ITEMS; i++) {
@@ -278,9 +280,9 @@ public class DeltaCacheTest {
         assertEquals(TEST_USERNAME, savedPerson.getUsername());
 
         store.pushBlocking();
-        Person downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
-        assertNotNull(downloadedPerson);
-        assertEquals(TEST_USERNAME, downloadedPerson.getUsername());
+        assertEquals(1, store.pullBlocking(client.query()).getCount());
+        assertNotNull(store.find().get(0));
+        assertEquals(TEST_USERNAME, store.find().get(0).getUsername());
 
         List<Person> personList = store.find();
         Person person1 = personList.get(0);
@@ -306,12 +308,12 @@ public class DeltaCacheTest {
         assertNotNull(callback.getResult().getUsername());
         assertEquals(TEST_USERNAME, callback.getResult().getUsername());
 
-        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, client.query());
+        CustomKinveySyncCallback syncCallback = testManager.sync(store, client.query());
         assertNotNull(syncCallback);
         assertNotNull(syncCallback.getResult());
         assertNull(syncCallback.getError());
-        assertNotNull(syncCallback.getResult().getResult().get(0).getUsername());
-        assertEquals(TEST_USERNAME, syncCallback.getResult().getResult().get(0).getUsername());
+        assertNotNull(syncCallback.getResult().getCount());
+        assertEquals(1, syncCallback.getResult().getCount());
 
         List<Person> personList = testManager.find(store, client.query()).getResult();
         Person changedPerson = personList.get(0);
@@ -332,8 +334,7 @@ public class DeltaCacheTest {
         assertNotNull(syncCallback);
         assertNotNull(syncCallback.getResult());
         assertNull(syncCallback.getError());
-        assertNotNull(syncCallback.getResult().getResult().get(0).getUsername());
-        assertEquals("DeltaCacheUserName_changed", syncCallback.getResult().getResult().get(0).getUsername());
+        assertNotNull(syncCallback.getResult().getCount());
 
         personList = testManager.find(store, client.query()).getResult();
         Person person1 = personList.get(0);
@@ -357,9 +358,9 @@ public class DeltaCacheTest {
         assertEquals(TEST_USERNAME, savedPerson.getUsername());
 
         store.pushBlocking();
-        Person downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
+        store.pullBlocking(client.query());
+        Person downloadedPerson = store.find().get(0);
         assertNotNull(downloadedPerson);
-        assertEquals(TEST_USERNAME, downloadedPerson.getUsername());
 
         List<Person> personList = store.find();
         Person changedPerson = personList.get(0);
@@ -377,7 +378,8 @@ public class DeltaCacheTest {
         assertEquals("DeltaCacheUserName_changed", changedPerson1.getUsername());
 
         store.pushBlocking();
-        downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
+        store.pullBlocking(client.query());
+        downloadedPerson = store.find().get(0); 
         assertNotNull(downloadedPerson);
         assertEquals("DeltaCacheUserName_changed", downloadedPerson.getUsername());
 
@@ -405,12 +407,12 @@ public class DeltaCacheTest {
         assertNotNull(callback.getResult().getUsername());
         assertEquals(TEST_USERNAME, callback.getResult().getUsername());
 
-        CustomKinveySyncCallback<Person> syncCallback = testManager.sync(store, client.query());
+        CustomKinveySyncCallback syncCallback = testManager.sync(store, client.query());
         assertNotNull(syncCallback);
         assertNotNull(syncCallback.getResult());
         assertNull(syncCallback.getError());
-        assertNotNull(syncCallback.getResult().getResult().get(0).getUsername());
-        assertEquals(TEST_USERNAME, syncCallback.getResult().getResult().get(0).getUsername());
+        assertNotNull(syncCallback.getResult().getCount());
+        assertEquals(1, syncCallback.getResult().getCount());
 
         List<Person> personList = testManager.find(store, client.query()).getResult();
         Person foundPerson = personList.get(0);
@@ -431,7 +433,7 @@ public class DeltaCacheTest {
         assertNotNull(syncCallback);
         assertNotNull(syncCallback.getResult());
         assertNull(syncCallback.getError());
-        assertEquals(0, syncCallback.getResult().getResult().size());
+        assertEquals(0, syncCallback.getResult().getCount());
 
         personList = testManager.find(store, client.query()).getResult();
         assertEquals(0, personList.size());
@@ -454,9 +456,9 @@ public class DeltaCacheTest {
         assertEquals(TEST_USERNAME, savedPerson.getUsername());
 
         store.pushBlocking();
-        Person downloadedPerson = store.pullBlocking(client.query()).getResult().get(0);
-        assertNotNull(downloadedPerson);
-        assertEquals(TEST_USERNAME, downloadedPerson.getUsername());
+        assertEquals(1, store.pullBlocking(client.query()).getCount());
+        assertNotNull(store.find().get(0));
+        assertEquals(TEST_USERNAME, store.find().get(0).getUsername());
 
         List<Person> personList = store.find();
         Person foundPerson = personList.get(0);
@@ -472,7 +474,8 @@ public class DeltaCacheTest {
         assertEquals(1, store.syncCount());
 
         store.pushBlocking();
-        List<Person> downloadedPersons = store.pullBlocking(client.query()).getResult();
+        store.pullBlocking(client.query());
+        List<Person> downloadedPersons = store.find();
         assertNotNull(downloadedPersons);
         assertEquals(0, downloadedPersons.size());
 
@@ -495,11 +498,11 @@ public class DeltaCacheTest {
         testManager.createPersons(store, TEN_ITEMS);
         testManager.sync(store, client.query());
 
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, client.query());
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, client.query());
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
-        assertEquals(TEN_ITEMS, pullCallback.getResult().getResult().size());
+        assertEquals(TEN_ITEMS, pullCallback.getResult().getCount());
 
         DefaultKinveyDeleteCallback deleteCallback = testManager.delete(networkStore, client.query().equals("username", TEST_USERNAME + 0));
         assertNotNull(deleteCallback);
@@ -511,7 +514,7 @@ public class DeltaCacheTest {
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
-        assertEquals(TEN_ITEMS - 1, pullCallback.getResult().getResult().size());
+        assertEquals(TEN_ITEMS - 1, pullCallback.getResult().getCount());
 
         List<Person> personList = testManager.find(store, client.query()).getResult();
         assertEquals(TEN_ITEMS - 1, personList.size());
@@ -530,11 +533,11 @@ public class DeltaCacheTest {
         testManager.createPersons(store, TEN_ITEMS);
         testManager.sync(store, client.query());
 
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, client.query());
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, client.query());
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
-        assertEquals(TEN_ITEMS, pullCallback.getResult().getResult().size());
+        assertEquals(TEN_ITEMS, pullCallback.getResult().getCount());
 
         DefaultKinveyClientCallback saveCallback = testManager.save(networkStore, new Person(TEST_USERNAME + TEN_ITEMS));
         assertNotNull(saveCallback);
@@ -546,7 +549,7 @@ public class DeltaCacheTest {
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
-        assertEquals(TEN_ITEMS + 1, pullCallback.getResult().getResult().size());
+        assertEquals(TEN_ITEMS + 1, pullCallback.getResult().getCount());
 
         List<Person> personList = testManager.find(store, client.query()).getResult();
         assertEquals(TEN_ITEMS + 1, personList.size());
@@ -573,12 +576,14 @@ public class DeltaCacheTest {
         assertNull(saveCallback.getError());
         assertEquals(TEST_USERNAME + 100, saveCallback.getResult().getUsername());
 
-        CustomKinveyPullCallback<Person> pullCallback = testManager.pullCustom(store, client.query().addSort("_kmd.lmt", AbstractQuery.SortOrder.ASC));
+        Query query = client.query().addSort("_kmd.lmt", AbstractQuery.SortOrder.ASC);
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, query);
         assertNotNull(pullCallback);
         assertNotNull(pullCallback.getResult());
         assertNull(pullCallback.getError());
-        assertEquals(TEN_ITEMS, pullCallback.getResult().getResult().size());
-        assertEquals(TEST_USERNAME + 100, pullCallback.getResult().getResult().get(9).getUsername());
+        assertEquals(TEN_ITEMS, pullCallback.getResult().getCount());
+
+        assertEquals(TEST_USERNAME + 100, store.find(query).get(9).getUsername());
 
         List<Person> personList = testManager.find(store, client.query().equals("username", TEST_USERNAME + 100)).getResult();
         assertEquals(1, personList.size());

--- a/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/AsyncPullRequest.java
@@ -17,7 +17,7 @@
 package com.kinvey.android;
 
 import com.kinvey.android.sync.KinveyPullCallback;
-import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.model.KinveyPullResponse;
 import com.kinvey.java.Query;
 import com.kinvey.java.model.KinveyAbstractReadResponse;
 import com.kinvey.java.store.BaseDataStore;
@@ -28,7 +28,7 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Class represents internal implementation of Async pull request that is used to create pull
  */
-public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T>> {
+public class AsyncPullRequest extends AsyncClientRequest<KinveyPullResponse> {
     private final BaseDataStore store;
     private Query query;
 
@@ -40,7 +40,7 @@ public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T
      */
     public AsyncPullRequest(BaseDataStore store,
                             Query query,
-                            KinveyPullCallback<T> callback){
+                            KinveyPullCallback callback){
         super(callback);
         this.query = query;
         this.store = store;
@@ -48,11 +48,7 @@ public class AsyncPullRequest<T> extends AsyncClientRequest<KinveyPullResponse<T
 
 
     @Override
-    protected KinveyPullResponse<T> executeAsync() throws IOException, InvocationTargetException, IllegalAccessException {
-        KinveyPullResponse<T> kinveyPullResponse = new KinveyPullResponse<T>();
-        KinveyAbstractReadResponse<T> pullResponse = store.pullBlocking(query);
-        kinveyPullResponse.setListOfExceptions(pullResponse.getListOfExceptions());
-        kinveyPullResponse.setResult(pullResponse.getResult());
-        return kinveyPullResponse;
+    protected KinveyPullResponse executeAsync() throws IOException, InvocationTargetException, IllegalAccessException {
+        return store.pullBlocking(query);
     }
 }

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
@@ -16,8 +16,6 @@
 
 package com.kinvey.android.async;
 
-import android.util.Log;
-
 import com.google.api.client.json.GenericJson;
 import com.kinvey.android.AsyncClientRequest;
 import com.kinvey.android.sync.KinveyPushCallback;
@@ -31,17 +29,16 @@ import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncItem;
 import com.kinvey.java.sync.dto.SyncRequest;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.ExecutionException;
-
-import static com.kinvey.android.Client.TAG;
 
 /**
  * Class represents internal implementation of Async push request that is used to create push

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -780,7 +780,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * @param query {@link Query} to filter the results or null if you don't want to query.
      * @param callback KinveyDeleteCallback
      */
-    public void sync(final Query query, final KinveySyncCallback<T> callback) {
+    public void sync(final Query query, final KinveySyncCallback callback) {
         callback.onPushStarted();
         push(new KinveyPushCallback() {
             @Override
@@ -821,7 +821,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      *
      * @param callback callback to notify working thread on operation status update
      */
-    public void sync(final KinveySyncCallback<T> callback) {
+    public void sync(final KinveySyncCallback callback) {
         sync(null, callback);
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/DataStore.java
@@ -29,7 +29,7 @@ import com.kinvey.android.callback.KinveyDeleteCallback;
 import com.kinvey.android.callback.KinveyListCallback;
 import com.kinvey.android.callback.KinveyPurgeCallback;
 import com.kinvey.android.sync.KinveyPullCallback;
-import com.kinvey.android.sync.KinveyPullResponse;
+import com.kinvey.java.model.KinveyPullResponse;
 import com.kinvey.android.sync.KinveyPushCallback;
 import com.kinvey.android.sync.KinveyPushResponse;
 import com.kinvey.android.sync.KinveySyncCallback;
@@ -657,7 +657,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
     /**
      * Asynchronous request to pull a collection of entites from backend.
      * <p>
-     * Creates an asynchronous request to pull an entity from backend.  Uses KinveyPullCallback<T> to return a
+     * Creates an asynchronous request to pull an entity from backend.  Uses KinveyPullCallback to return a
      * {@link KinveyPullResponse}.
      * </p>
      * <p>
@@ -678,16 +678,16 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * @param query {@link Query} to filter the results.
      * @param callback KinveyPullCallback
      */
-    public void pull(Query query, KinveyPullCallback<T> callback) {
+    public void pull(Query query, KinveyPullCallback callback) {
         Preconditions.checkNotNull(client, "client must not be null");
         Preconditions.checkArgument(client.isInitialize(), "client must be initialized.");
-        new AsyncPullRequest<T>(this, query, callback).execute();
+        new AsyncPullRequest(this, query, callback).execute();
     }
 
     /**
      * Asynchronous request to pull a collection of entites from backend.
      * <p>
-     * Creates an asynchronous request to pull all entity from backend.  Uses KinveyPullCallback<T> to return a
+     * Creates an asynchronous request to pull all entity from backend.  Uses KinveyPullCallback to return a
      * {@link KinveyPullResponse}.
      * </p>
      * <p>
@@ -705,7 +705,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      *
      * @param callback KinveyPullCallback
      */
-    public void pull(KinveyPullCallback<T> callback) {
+    public void pull(KinveyPullCallback callback) {
         this.pull(null, callback);
     }
 
@@ -713,7 +713,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      * Asynchronous request to clear all the pending requests from the sync storage
      * <p>
      * Creates an asynchronous request to clear all the pending requests from the sync storage.
-     * Uses KinveyPullCallback<T> to return a {@link KinveyPurgeCallback}.
+     * Uses KinveyPullCallback to return a {@link KinveyPurgeCallback}.
      * </p>
      * <p>
      * Sample Usage:
@@ -764,7 +764,7 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
      *     myQuery.equals("age",21);
      *     myAppData.sync(myQuery, new KinveySyncCallback {
      *     public void onSuccess(KinveyPushResponse kinveyPushResponse,
-     *         KinveyPullResponse<T> kinveyPullResponse) {...}
+     *         KinveyPullResponse kinveyPullResponse) {...}
      *         void onSuccess(){...};
      *         void onPullStarted(){...};
      *         void onPushStarted(){...};
@@ -787,10 +787,10 @@ public class DataStore<T extends GenericJson> extends BaseDataStore<T> {
             public void onSuccess(final KinveyPushResponse pushResult) {
                 callback.onPushSuccess(pushResult);
                 callback.onPullStarted();
-                DataStore.this.pull(query, new KinveyPullCallback<T>() {
+                DataStore.this.pull(query, new KinveyPullCallback() {
 
                     @Override
-                    public void onSuccess(KinveyPullResponse<T> pullResult) {
+                    public void onSuccess(KinveyPullResponse pullResult) {
                         callback.onPullSuccess(pullResult);
                         callback.onSuccess(pushResult, pullResult);
                     }

--- a/android-lib/src/main/java/com/kinvey/android/sync/KinveyPullCallback.java
+++ b/android-lib/src/main/java/com/kinvey/android/sync/KinveyPullCallback.java
@@ -17,17 +17,18 @@
 package com.kinvey.android.sync;
 
 import com.kinvey.java.core.KinveyClientCallback;
+import com.kinvey.java.model.KinveyPullResponse;
 
 /**
  * This class provides callbacks from requests executed by the Sync API.
  *
  * @author mvakulich
  */
-public interface KinveyPullCallback<T> extends KinveyClientCallback<KinveyPullResponse<T>> {
+public interface KinveyPullCallback extends KinveyClientCallback<KinveyPullResponse> {
     /**
      * Used to indicate successful execution of a request by the background service.
      */
-    void onSuccess(KinveyPullResponse<T> result);
+    void onSuccess(KinveyPullResponse result);
 
     /**
      * Used to indicate the failed execution of a request by the background service.

--- a/android-lib/src/main/java/com/kinvey/android/sync/KinveyPullResponse.java
+++ b/android-lib/src/main/java/com/kinvey/android/sync/KinveyPullResponse.java
@@ -1,8 +1,0 @@
-package com.kinvey.android.sync;
-
-import com.kinvey.java.model.KinveyAbstractReadResponse;
-
-public class KinveyPullResponse<T> extends KinveyAbstractReadResponse<T> {
-
-
-}

--- a/android-lib/src/main/java/com/kinvey/android/sync/KinveySyncCallback.java
+++ b/android-lib/src/main/java/com/kinvey/android/sync/KinveySyncCallback.java
@@ -23,7 +23,7 @@ import com.kinvey.java.model.KinveyPullResponse;
  *
  * @author edwardf
  */
-public interface KinveySyncCallback<T> {
+public interface KinveySyncCallback {
 
     void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse kinveyPullResponse);
 
@@ -38,12 +38,12 @@ public interface KinveySyncCallback<T> {
     void onPushStarted();
 
     /**
-     * Used to indicate successfull execution of pull request by background service
+     * Used to indicate successful execution of pull request by background service
      */
     void onPullSuccess(KinveyPullResponse kinveyPullResponse);
 
     /**
-     * Used to indicate successfull execution of push request by background service
+     * Used to indicate successful execution of push request by background service
      */
     void onPushSuccess(KinveyPushResponse kinveyPushResponse);
 

--- a/android-lib/src/main/java/com/kinvey/android/sync/KinveySyncCallback.java
+++ b/android-lib/src/main/java/com/kinvey/android/sync/KinveySyncCallback.java
@@ -16,6 +16,8 @@
 package com.kinvey.android.sync;
 
 
+import com.kinvey.java.model.KinveyPullResponse;
+
 /**
  * This class provides callbacks from requests executed by the Sync API.
  *
@@ -23,7 +25,7 @@ package com.kinvey.android.sync;
  */
 public interface KinveySyncCallback<T> {
 
-    void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse<T> kinveyPullResponse);
+    void onSuccess(KinveyPushResponse kinveyPushResponse, KinveyPullResponse kinveyPullResponse);
 
     /**
      * Used to indicate start of pull request by background service
@@ -38,7 +40,7 @@ public interface KinveySyncCallback<T> {
     /**
      * Used to indicate successfull execution of pull request by background service
      */
-    void onPullSuccess(KinveyPullResponse<T> kinveyPullResponse);
+    void onPullSuccess(KinveyPullResponse kinveyPullResponse);
 
     /**
      * Used to indicate successfull execution of push request by background service

--- a/java-api-core/src/com/kinvey/java/model/KinveyPullResponse.java
+++ b/java-api-core/src/com/kinvey/java/model/KinveyPullResponse.java
@@ -1,0 +1,15 @@
+package com.kinvey.java.model;
+
+
+public class KinveyPullResponse extends KinveyAbstractResponse {
+
+    private int count;
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}


### PR DESCRIPTION
#### Description
`KinveyPullResponse` has to return count of pulled items instead of list of items. 

#### Changes
The PR has breaking changes:
Users have to: 
1. Remove old import for `KinveyPullResponse`
`import com.kinvey.android.sync.KinveyPullResponse;`
and add a new one `import com.kinvey.java.model.KinveyPullResponse;`.
2. Remove GenericType from `KinveyPullResponse<Book> `, `KinveySyncCallback<Book>`, `KinveyPullCallback<Book>`, it should look like `KinveyPullResponse`, `KinveySyncCallback`, `KinveyPullCallback`.
The method  `public List<T> getResult()` was changed to `public int getCount()` in the `KinveyPullResponse` class.

#### Tests
Instrumented
