### PR TITLE
feat: MLIBZ-2433 Enable instance.id in properties file

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
@@ -177,4 +177,11 @@ public class ClientBuilderTest {
         assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_AUTH + "/", client.getMICHostName());
     }
 
+    @Test
+    public void testSetInstanceIdAndSetBaseUrl() throws IOException {
+        client = new Client.Builder(mContext).setBaseUrl("BaseUrl").setInstanceID("TestInstanceId").build();
+        assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_API + "/", client.getBaseUrl());
+        assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_AUTH + "/", client.getMICHostName());
+    }
+
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
@@ -179,7 +179,7 @@ public class ClientBuilderTest {
 
     @Test
     public void testSetInstanceIdAndSetBaseUrl() throws IOException {
-        client = new Client.Builder(mContext).setBaseUrl("BaseUrl").setInstanceID("TestInstanceId").build();
+        client = new Client.Builder(mContext).setBaseUrl("https://baseurl.com").setInstanceID("TestInstanceId").build();
         assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_API + "/", client.getBaseUrl());
         assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_AUTH + "/", client.getMICHostName());
     }

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -581,6 +581,10 @@ public class Client<T extends User> extends AbstractClient<T> {
                 this.setBaseUrl(super.getString(Option.BASE_URL));
             }
 
+            if (super.getString(Option.INSTANCE_ID) != null) {
+                this.setInstanceID(super.getString(Option.INSTANCE_ID));
+            }
+
             if (super.getString(Option.REQUEST_TIMEOUT) != null) {
                 try {
                     this.setRequestTimeout(Integer.parseInt(super.getString(Option.REQUEST_TIMEOUT)));

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -482,6 +482,8 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
          *
          */
         public enum Option {
+            /** Optional. Used to base url generating */
+            INSTANCE_ID("instance.id"),
             /** Optional. Usually the base url minus the port e.g. {@code http://api.kinvey.com} */
             BASE_URL("api.base.url"),
             /** Optional. Usually 80 and used to build the api base url */


### PR DESCRIPTION
#### Description
Enable instance.id in properties file

#### Changes
Added instance.id  as a possible parameter to the properties file.
If `setBaseUrl` and `setInstanceId` are used in the `Client.Builder`, the order of these methods call is important, last option will be used. For examle `(Client.Builder(mContext).setBaseUrl("BaseUrl").setInstanceID("TestInstanceId").build())`, in this case `instanceID` will be used, if `setBaseUrl` will be after `setInstanceID` then `baseUrl` parameter will be used.
For properties file, the options order doesn't matter, in all cases, `instanceID` will be used if it exists.

#### Tests
Instrumented, Manual
