### PR TITLE
feat: MLIBZ-2448 Fix setting client app version

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/ClientBuilderTest.java
@@ -11,6 +11,7 @@ import com.kinvey.android.model.User;
 import com.kinvey.androidTest.model.TestUser;
 import com.kinvey.java.Constants;
 import com.kinvey.java.KinveyException;
+import com.kinvey.BuildConfig;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -182,6 +183,15 @@ public class ClientBuilderTest {
         client = new Client.Builder(mContext).setBaseUrl("https://baseurl.com").setInstanceID("TestInstanceId").build();
         assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_API + "/", client.getBaseUrl());
         assertEquals(Constants.PROTOCOL_HTTPS + "TestInstanceId" + Constants.HYPHEN + Constants.HOSTNAME_AUTH + "/", client.getMICHostName());
+    }
+
+    @Test
+    public void testAppVersionExists() {
+        client = new Client.Builder(mContext).build();
+        assertNotNull(client.getClientAppVersion());
+        assertTrue(!"".equals(client.getClientAppVersion()));
+        assertEquals(BuildConfig.VERSION, client.getClientAppVersion());
+        System.out.println("client version: " + client.getClientAppVersion());
     }
 
 }

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -46,6 +46,7 @@ import com.kinvey.java.store.BaseDataStore;
 import com.kinvey.java.store.BaseFileStore;
 import com.kinvey.java.store.StoreType;
 import com.kinvey.java.sync.SyncManager;
+import com.kinvey.BuildConfig;
 
 /**
  * The core Kinvey client used to access Kinvey's BaaS.
@@ -85,7 +86,7 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
     /** Class to use for representing a BaseUser **/
     private Class userModelClass = BaseUser.class;
     
-    private String clientAppVersion = null;
+    private String clientAppVersion = BuildConfig.VERSION;
     
     private GenericData customRequestProperties = new GenericData();
 


### PR DESCRIPTION
#### Description
Client app version is null in `client.getClientAppVersion()`. Requests to data storage at the backend have client app version in headers. 

#### Changes
Added setting client app version from `BuildConfig.VERSION` as default value for `clientAppVersion` fileld in the `AbstractClient`.

#### Tests
Instrumental
