### PR TITLE
feat: MLIBZ-2447 Extending user class with properties of different class cause an exception

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/InternalUserEntity.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/InternalUserEntity.java
@@ -1,0 +1,18 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+public class InternalUserEntity extends GenericJson {
+
+    @Key
+    private String street;
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/TestUser.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/TestUser.java
@@ -8,9 +8,8 @@ public class TestUser extends User {
     @Key("companyName")
     private String companyName;
 
-    public TestUser() {
-
-    }
+    @Key
+    private InternalUserEntity internalUserEntity;
 
     public String getCompanyName() {
         return companyName;
@@ -18,5 +17,13 @@ public class TestUser extends User {
 
     public void setCompanyName(String companyName) {
         this.companyName = companyName;
+    }
+
+    public InternalUserEntity getInternalUserEntity() {
+        return internalUserEntity;
+    }
+
+    public void setInternalUserEntity(InternalUserEntity internalUserEntity) {
+        this.internalUserEntity = internalUserEntity;
     }
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/UserStoreTest.java
@@ -20,6 +20,7 @@ import com.kinvey.android.model.User;
 import com.kinvey.android.store.DataStore;
 import com.kinvey.android.store.UserStore;
 import com.kinvey.androidTest.LooperThread;
+import com.kinvey.androidTest.model.InternalUserEntity;
 import com.kinvey.androidTest.model.Person;
 import com.kinvey.androidTest.model.TestUser;
 import com.kinvey.java.Query;
@@ -1125,6 +1126,9 @@ public class UserStoreTest {
         client.setUserClass(TestUser.class);
         TestUser user = new TestUser();
         user.setCompanyName("Test Company");
+        InternalUserEntity internalUserEntity = new InternalUserEntity();
+        internalUserEntity.setStreet("TestStreet");
+        user.setInternalUserEntity(internalUserEntity);
         CustomKinveyClientCallback callback = signUp(user);
         assertNull(callback.error);
         assertNotNull(callback.result);
@@ -1135,6 +1139,7 @@ public class UserStoreTest {
         CustomKinveyClientCallback userKinveyClientCallback = updateCustomUser(client);
         assertNotNull(userKinveyClientCallback.result);
         assertNotEquals(user.getCompanyName(), userKinveyClientCallback.result.getCompanyName());
+        assertNotEquals(user.getInternalUserEntity().getStreet(), userKinveyClientCallback.result.getInternalUserEntity().getStreet());
         assertNotNull(deleteUser(true, client));
     }
 

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/UserStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/UserStoreTest.java
@@ -379,11 +379,17 @@ public class UserStoreTest {
         client.setUserClass(TestUser.class);
         TestUser user = new TestUser();
         user.setCompanyName("Test Company");
+        InternalUserEntity internalUserEntity = new InternalUserEntity();
+        internalUserEntity.setStreet("TestStreet");
+        user.setInternalUserEntity(internalUserEntity);
         CustomKinveyClientCallback callback = signUp(user);
         assertNull(callback.error);
         assertNotNull(callback.result);
-        destroyUser();
         assertEquals(user.getCompanyName(), callback.result.getCompanyName());
+        assertEquals("TestStreet", callback.result.getInternalUserEntity().getStreet());
+        assertEquals("Test Company", ((TestUser)client.getActiveUser()).getCompanyName());
+        assertEquals("TestStreet", ((TestUser)client.getActiveUser()).getInternalUserEntity().getStreet());
+        destroyUser();
     }
 
     @Test
@@ -1136,10 +1142,11 @@ public class UserStoreTest {
         assertEquals(user.getCompanyName(), callback.result.getCompanyName(), client.getActiveUser().get("companyName"));
 
         client.getActiveUser().set("companyName", "New Company");
+        ((TestUser) client.getActiveUser()).getInternalUserEntity().setStreet("TestStreet2");
         CustomKinveyClientCallback userKinveyClientCallback = updateCustomUser(client);
         assertNotNull(userKinveyClientCallback.result);
-        assertNotEquals(user.getCompanyName(), userKinveyClientCallback.result.getCompanyName());
-        assertNotEquals(user.getInternalUserEntity().getStreet(), userKinveyClientCallback.result.getInternalUserEntity().getStreet());
+        assertEquals("New Company", userKinveyClientCallback.result.getCompanyName());
+        assertEquals("TestStreet2", userKinveyClientCallback.result.getInternalUserEntity().getStreet());
         assertNotNull(deleteUser(true, client));
     }
 

--- a/android-lib/src/main/java/com/kinvey/android/Client.java
+++ b/android-lib/src/main/java/com/kinvey/android/Client.java
@@ -431,7 +431,7 @@ public class Client<T extends User> extends AbstractClient<T> {
      * <p/>
      * This Builder class is not thread-safe.
      */
-    public static class Builder extends AbstractClient.Builder {
+    public static class Builder<T extends User> extends AbstractClient.Builder {
 
         private Context context = null;
         private KinveyUserCallback<User> retrieveUserCallback = null;
@@ -447,7 +447,7 @@ public class Client<T extends User> extends AbstractClient<T> {
         private String MICVersion;
         private String MICBaseURL;
         private boolean deltaSetCache = false;
-        private Class userClass = User.class;
+        private Class userClass = null;
         private byte[] encryptionKey;
 
         /**
@@ -764,7 +764,7 @@ public class Client<T extends User> extends AbstractClient<T> {
             this(context, newCompatibleTransport());
         }
 
-        public Builder setUserClass(Class userClass){
+        public Builder setUserClass(Class<T> userClass){
             this.userClass = userClass;
             return this;
         }
@@ -795,18 +795,18 @@ public class Client<T extends User> extends AbstractClient<T> {
          * which contains factory methods for accessing various functionality.
          */
         @Override
-        public Client build(){
+        public Client<T> build(){
             kinveyHandlerThread = new KinveyHandlerThread("KinveyHandlerThread");
             kinveyHandlerThread.start();
             Realm.init(context);
-            final Client client = new Client(getTransport(),
+            final Client<T> client = new Client<>(getTransport(),
                     getHttpRequestInitializer(), getBaseUrl(),
                     getServicePath(), this.getObjectParser(), getKinveyClientRequestInitializer(), getCredentialStore(),
                     getRequestBackoffPolicy(), this.encryptionKey, this.context);
 
             client.clientUser = AndroidUserStore.getUserStore(this.context);
 
-            client.setUserClass(userClass);
+            client.setUserClass(userClass != null ? userClass : User.class);
 
             //GCM explicitly enabled
             if (this.GCM_Enabled){
@@ -858,7 +858,7 @@ public class Client<T extends User> extends AbstractClient<T> {
          *
          * </p>
          *
-         * @param buildCallback Instance of {@link: KinveyClientBuilderCallback}
+         * @param buildCallback Instance of {@link KinveyClientBuilderCallback}
          */
         public void build(KinveyClientBuilderCallback buildCallback) {
             new Build(buildCallback).execute();
@@ -868,7 +868,7 @@ public class Client<T extends User> extends AbstractClient<T> {
         /**
          * Define how credentials will be stored
          *
-         * @param store something implpemting CredentialStore interface
+         * @param store something implementing CredentialStore interface
          * @return this builder, with the new credential store set
          */
         public Builder setCredentialStore(CredentialStore store) {
@@ -894,7 +894,7 @@ public class Client<T extends User> extends AbstractClient<T> {
          * Sets a callback to be called after a client is intialized and BaseUser attributes is being retrieved.
          *
          * <p>
-         * When a client is intialized after an initial login, the user's credentials are cached locally and used for the
+         * When a client is initialized after an initial login, the user's credentials are cached locally and used for the
          * initialization of the client.  As part of the initialization process, a background thread is spawned to retrieve
          * up-to-date user attributes.  This optional callback is called when the retrieval process is complete and passes
          * an instance of the logged in user.

--- a/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
+++ b/android-lib/src/main/java/com/kinvey/android/store/UserStore.java
@@ -28,6 +28,7 @@ import com.kinvey.java.store.requests.user.GetMICTempURL;
 import com.kinvey.java.store.requests.user.LoginToTempURL;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.List;
 
 public class UserStore {
@@ -60,12 +61,12 @@ public class UserStore {
      * @param client {@link Client} an instance of the client
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      */
-    public static void signUp(String username, String password, AbstractClient client, KinveyClientCallback<User> callback) {
+    public static void signUp(String username, String password, AbstractClient<User> client, KinveyClientCallback<User> callback) {
         signUp(username, password, null, client, callback);
     }
 
-    public static <T extends User> void signUp(String username, String password, T user, AbstractClient client, KinveyClientCallback<T> callback) {
-        new Create(username, password, user, client, callback).execute();
+    public static <T extends User> void signUp(String username, String password, T user, AbstractClient<T> client, KinveyClientCallback<T> callback) {
+        new Create<>(username, password, user, client, callback).execute();
     }
 
     /**
@@ -91,8 +92,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void login(AbstractClient client, KinveyClientCallback<User> callback) throws IOException {
-        new Login(client, callback).execute();
+    public static <T extends User> void login(AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(client, callback).execute();
     }
 
     /**
@@ -120,8 +121,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void login(String userId, String password, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(userId, password, client, callback).execute();
+    public static <T extends User> void login(String userId, String password, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(userId, password, client, callback).execute();
     }
 
     /**
@@ -147,8 +148,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginFacebook(String accessToken, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, UserStoreRequestManager.LoginType.FACEBOOK, client, callback).execute();
+    public static  <T extends User> void loginFacebook(String accessToken, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, UserStoreRequestManager.LoginType.FACEBOOK, client, callback).execute();
     }
 
     /**
@@ -174,8 +175,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginGoogle(String accessToken, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, UserStoreRequestManager.LoginType.GOOGLE, client, callback).execute();
+    public static <T extends User> void loginGoogle(String accessToken, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, UserStoreRequestManager.LoginType.GOOGLE, client, callback).execute();
     }
 
     /**
@@ -206,8 +207,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginTwitter(String accessToken, String accessSecret, String consumerKey, String consumerSecret, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, accessSecret, consumerKey, consumerSecret, client, UserStoreRequestManager.LoginType.TWITTER, callback).execute();
+    public static <T extends User> void loginTwitter(String accessToken, String accessSecret, String consumerKey, String consumerSecret, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, accessSecret, consumerKey, consumerSecret, client, UserStoreRequestManager.LoginType.TWITTER, callback).execute();
     }
 
     /**
@@ -238,8 +239,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginLinkedIn(String accessToken, String accessSecret, String consumerKey, String consumerSecret, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, accessSecret, consumerKey, consumerSecret, client, UserStoreRequestManager.LoginType.LINKED_IN, callback).execute();
+    public static <T extends User> void loginLinkedIn(String accessToken, String accessSecret, String consumerKey, String consumerSecret, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, accessSecret, consumerKey, consumerSecret, client, UserStoreRequestManager.LoginType.LINKED_IN, callback).execute();
     }
 
     /**
@@ -265,8 +266,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginAuthLink(String accessToken, String refreshToken, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, refreshToken,UserStoreRequestManager.LoginType.AUTH_LINK, client, callback).execute();
+    public static <T extends User> void loginAuthLink(String accessToken, String refreshToken, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, refreshToken,UserStoreRequestManager.LoginType.AUTH_LINK, client, callback).execute();
     }
 
     /**
@@ -297,8 +298,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginSalesForce(String accessToken, String client_id, String refreshToken, String id, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, client_id, refreshToken, id, client, UserStoreRequestManager.LoginType.SALESFORCE, callback).execute();
+    public static <T extends User> void loginSalesForce(String accessToken, String client_id, String refreshToken, String id, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, client_id, refreshToken, id, client, UserStoreRequestManager.LoginType.SALESFORCE, callback).execute();
     }
 
     /**
@@ -323,8 +324,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void loginMobileIdentity(String accessToken, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(accessToken, UserStoreRequestManager.LoginType.MOBILE_IDENTITY, client, callback).execute();
+    public static <T extends User> void loginMobileIdentity(String accessToken, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(accessToken, UserStoreRequestManager.LoginType.MOBILE_IDENTITY, client, callback).execute();
     }
 
     /**
@@ -350,8 +351,8 @@ public class UserStore {
      * @param callback {@link com.kinvey.java.core.KinveyClientCallback<User>} the callback
      * @throws IOException
      */
-    public static void login(Credential credential, AbstractClient client, KinveyClientCallback callback) throws IOException {
-        new Login(credential, client, callback).execute();
+    public static <T extends User> void login(Credential credential, AbstractClient client, KinveyClientCallback<T> callback) throws IOException {
+        new Login<>(credential, client, callback).execute();
     }
 
     /**
@@ -362,8 +363,8 @@ public class UserStore {
      * @param authToken a valid Kinvey Auth token
      * @param callback {@link KinveyUserCallback} that contains a valid logged in user
      */
-    public void loginKinveyAuthToken(String userId, String authToken, AbstractClient client, KinveyClientCallback callback){
-        new LoginKinveyAuth(userId, authToken, client, callback).execute();
+    public <T extends User> void loginKinveyAuthToken(String userId, String authToken, AbstractClient client, KinveyClientCallback<T> callback){
+        new LoginKinveyAuth<>(userId, authToken, client, callback).execute();
     }
 
     /**
@@ -480,8 +481,8 @@ public class UserStore {
         new ChangePassword(password, client, callback).execute();
     }
 
-    public static void get(String userId, AbstractClient client, KinveyUserManagementCallback callback) {
-        new GetUser(userId, client, callback).execute();
+    public static <T extends User> void get(String userId, AbstractClient client, KinveyClientCallback<T> callback) {
+        new GetUser<>(userId, client, callback).execute();
     }
 
     /**
@@ -504,8 +505,8 @@ public class UserStore {
      *
      * @param callback KinveyUserCallback
      */
-    public static void convenience(AbstractClient client,KinveyClientCallback<User> callback) {
-        new RetrieveMetaData(client, callback).execute();
+    public static  <T extends User> void convenience(AbstractClient client,KinveyClientCallback<T> callback) {
+        new RetrieveMetaData<>(client, callback).execute();
     }
 
     /**
@@ -577,8 +578,8 @@ public class UserStore {
      * @param client {@link Client} an instance of the client
      * @param callback {@link KinveyUserCallback} containing refreshed user instance
      */
-    public static void retrieve(String[] resolves, AbstractClient client, KinveyClientCallback<User> callback){
-        new Retrieve(resolves, client, callback).execute();
+    public static <T extends User> void retrieve(String[] resolves, AbstractClient client, KinveyClientCallback<T> callback){
+        new Retrieve<T>(resolves, client, callback).execute();
     }
 
     /**
@@ -846,7 +847,7 @@ public class UserStore {
     }
 
 
-    private static class Login extends AsyncClientRequest<User> {
+    private static class Login<T extends BaseUser> extends AsyncClientRequest<T> {
 
         String username;
         String password;
@@ -857,13 +858,13 @@ public class UserStore {
         String consumerSecret;
         Credential credential;
         UserStoreRequestManager.LoginType type;
-        AbstractClient client;
+        AbstractClient<T> client;
 
         //Salesforce...
         String id;
         String client_id;
 
-        private Login(AbstractClient client, KinveyClientCallback<User> callback) {
+        private Login(AbstractClient client, KinveyClientCallback<T> callback) {
             super(callback);
 
             this.client = client;
@@ -928,7 +929,7 @@ public class UserStore {
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             switch(this.type) {
                 case IMPLICIT:
                     return BaseUserStore.login(client);
@@ -959,10 +960,10 @@ public class UserStore {
         String username;
         String password;
         private T user;
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
 
 
-        private Create(String username, String password, T user, AbstractClient client, KinveyClientCallback callback) {
+        private Create(String username, String password, T user, AbstractClient<T> client, KinveyClientCallback<T> callback) {
             super(callback);
             this.username=username;
             this.password=password;
@@ -1016,14 +1017,14 @@ public class UserStore {
         }
     }
 
-    private static class PostForAccessToken extends AsyncClientRequest<User>{
+    private static class PostForAccessToken<T extends User> extends AsyncClientRequest<T>{
 
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
         private final String redirectURI;
         private String token;
         private String clientId;
 
-        public PostForAccessToken(AbstractClient client, String redirectURI, String token, String clientId, KinveyClientCallback<User> callback) {
+        public PostForAccessToken(AbstractClient<T> client, String redirectURI, String token, String clientId, KinveyClientCallback<T> callback) {
             super(callback);
             this.client = client;
             this.redirectURI = redirectURI;
@@ -1033,12 +1034,12 @@ public class UserStore {
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             UserStoreRequestManager requestManager = new UserStoreRequestManager(client, createBuilder(client));
             requestManager.setMICRedirectURI(redirectURI);
             GenericJson result = requestManager.getMICToken(token, clientId).execute();
 
-            User ret =  BaseUserStore.loginMobileIdentity(result.get("access_token").toString(), client);
+            T ret =  BaseUserStore.loginMobileIdentity(result.get("access_token").toString(), client);
 
             Credential currentCred = client.getStore().load(client.getActiveUser().getId());
             currentCred.setRefreshToken(result.get("refresh_token").toString());
@@ -1049,15 +1050,15 @@ public class UserStore {
         }
     }
 
-    private static class PostForTempURL extends AsyncClientRequest<User>{
+    private static class PostForTempURL<T extends User> extends AsyncClientRequest<T>{
 
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
         private String clientId;
         private final String redirectURI;
         String username;
         String password;
 
-        public PostForTempURL(AbstractClient client, String clientId, String redirectURI, String username, String password, KinveyUserCallback<User> callback) {
+        public PostForTempURL(AbstractClient<T> client, String clientId, String redirectURI, String username, String password, KinveyUserCallback<T> callback) {
             super(callback);
             this.client = client;
             this.clientId = clientId;
@@ -1067,9 +1068,9 @@ public class UserStore {
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
 
-            UserStoreRequestManager requestManager = new UserStoreRequestManager(client, createBuilder(client));
+            UserStoreRequestManager<T> requestManager = new UserStoreRequestManager<>(client, createBuilder(client));
             requestManager.setMICRedirectURI(redirectURI);
             GetMICTempURL micTempURL = requestManager.getMICTempURL(clientId);
             GenericJson tempResult = micTempURL.execute();
@@ -1078,7 +1079,7 @@ public class UserStore {
             LoginToTempURL loginToTempURL = requestManager.MICLoginToTempURL(username, password, clientId, tempURL);
             GenericJson accessResult = loginToTempURL.execute();
 
-            User user = BaseUserStore.loginMobileIdentity(accessResult.get("access_token").toString(), client);
+            T user = BaseUserStore.loginMobileIdentity(accessResult.get("access_token").toString(), client);
 
 
             Credential currentCred = client.getStore().load(client.getActiveUser().getId());
@@ -1091,24 +1092,24 @@ public class UserStore {
     }
 
 
-    private static class Retrieve extends AsyncClientRequest<User> {
+    private static class Retrieve<T extends User> extends AsyncClientRequest<T> {
 
         private String[] resolves = null;
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
 
-        private Retrieve(AbstractClient client,KinveyClientCallback<User> callback) {
+        private Retrieve(AbstractClient<T> client,KinveyClientCallback<T> callback) {
             super(callback);
             this.client = client;
         }
 
-        private Retrieve(String[] resolves, AbstractClient client, KinveyClientCallback<User> callback){
+        private Retrieve(String[] resolves, AbstractClient<T> client, KinveyClientCallback<T> callback){
             super(callback);
             this.resolves = resolves;
             this.client = client;
         }
 
         @Override
-        public User executeAsync() throws IOException {
+        public T executeAsync() throws IOException {
             if (resolves == null){
                 return BaseUserStore.retrieve(client);
             }else{
@@ -1120,16 +1121,16 @@ public class UserStore {
     private static class RetrieveUserList<T extends BaseUser> extends AsyncClientRequest<List<T>> {
 
         private Query query = null;
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
         private String[] resolves = null;
 
-        private RetrieveUserList(Query query, AbstractClient client, KinveyListCallback<T> callback){
+        private RetrieveUserList(Query query, AbstractClient<T> client, KinveyListCallback<T> callback){
             super(callback);
             this.query = query;
             this.client = client;
         }
 
-        private RetrieveUserList(Query query, String[] resolves, AbstractClient client, KinveyListCallback<T> callback){
+        private RetrieveUserList(Query query, String[] resolves, AbstractClient<T> client, KinveyListCallback<T> callback){
             super(callback);
             this.query = query;
             this.resolves = resolves;
@@ -1146,13 +1147,13 @@ public class UserStore {
         }
     }
 
-    private static class RetrieveUserArray extends AsyncClientRequest<User[]> {
+    private static class RetrieveUserArray<T extends User> extends AsyncClientRequest<T[]> {
 
         private Query query = null;
         private String[] resolves = null;
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
 
-        private RetrieveUserArray(Query query, String[] resolves, AbstractClient client, KinveyClientCallback<User[]> callback){
+        private RetrieveUserArray(Query query, String[] resolves, AbstractClient<T> client, KinveyClientCallback<T[]> callback){
             super(callback);
             this.query = query;
             this.resolves = resolves;
@@ -1160,42 +1161,42 @@ public class UserStore {
         }
 
         @Override
-        public User[] executeAsync() throws IOException {
-            List<User> users = BaseUserStore.retrieve(query, resolves, client);
-            return users.toArray(new User[users.size()]);
+        public T[] executeAsync() throws IOException {
+            List<T> users = BaseUserStore.retrieve(query, resolves, client);
+            return users.toArray((T[])Array.newInstance(client.getUserClass(), 1));
         }
     }
 
-    private static class RetrieveMetaData extends AsyncClientRequest<User> {
+    private static class RetrieveMetaData<T extends User> extends AsyncClientRequest<T> {
 
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
 
 
-        private RetrieveMetaData(AbstractClient client, KinveyClientCallback<User> callback) {
+        private RetrieveMetaData(AbstractClient<T> client, KinveyClientCallback<T> callback) {
             super(callback);
             this.client = client;
 
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             return BaseUserStore.convenience(client);
         }
     }
 
-    private static class Update extends AsyncClientRequest<User> {
+    private static class Update<T extends User> extends AsyncClientRequest<T> {
 
-        AbstractClient client = null;
+        AbstractClient<T> client = null;
 
 
-        private Update(AbstractClient client, KinveyClientCallback<User> callback){
+        private Update(AbstractClient<T> client, KinveyClientCallback<T> callback){
             super(callback);
             this.client = client;
 
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             return BaseUserStore.save(client);
         }
     }
@@ -1260,13 +1261,13 @@ public class UserStore {
         }
     }
 
-    private static class GetUser extends AsyncClientRequest {
+    private static class GetUser<T extends User> extends AsyncClientRequest<T> {
 
         String userId;
         private final AbstractClient client;
 
 
-        private GetUser(String userId, AbstractClient client, KinveyClientCallback callback) {
+        private GetUser(String userId, AbstractClient client, KinveyClientCallback<T> callback) {
             super(callback);
             this.userId = userId;
             this.client = client;
@@ -1274,7 +1275,7 @@ public class UserStore {
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             BaseUserStore.get(userId, client);
             return null;
         }
@@ -1318,14 +1319,14 @@ public class UserStore {
         }
     }
 
-    private class LoginKinveyAuth extends AsyncClientRequest<User> {
+    private class LoginKinveyAuth<T extends User> extends AsyncClientRequest<T> {
 
         private String authToken;
-        private final AbstractClient client;
+        private final AbstractClient<T> client;
 
         private String userID;
 
-        private LoginKinveyAuth(String userId, String authToken, AbstractClient client, KinveyClientCallback callback){
+        private LoginKinveyAuth(String userId, String authToken, AbstractClient<T> client, KinveyClientCallback<T> callback){
             super(callback);
             this.userID = userId;
             this.authToken = authToken;
@@ -1334,17 +1335,17 @@ public class UserStore {
         }
 
         @Override
-        protected User executeAsync() throws IOException {
+        protected T executeAsync() throws IOException {
             return BaseUserStore.loginKinveyAuthToken(userID, authToken, client);
 
         }
     }
 
-    private static KinveyAuthRequest.Builder createBuilder(AbstractClient client) {
+    private static <T extends BaseUser> KinveyAuthRequest.Builder<T> createBuilder(AbstractClient<T> client) {
         String appKey = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppKey();
         String appSecret = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppSecret();
 
-        return new KinveyAuthRequest.Builder(client.getRequestFactory().getTransport(),
+        return new KinveyAuthRequest.Builder<>(client.getRequestFactory().getTransport(),
                 client.getJsonFactory(), client.getBaseUrl(), appKey, appSecret, null);
     }
 

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -83,7 +83,7 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
     private ArrayList<ClientExtension> extensions;
 
     /** Class to use for representing a BaseUser **/
-    private Class userModelClass = BaseUser.class;
+    private Class userModelClass = null;
     
     private String clientAppVersion = null;
     
@@ -560,15 +560,15 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
         return new SyncManager(getSyncCacheManager());
     }
 
-    public Class getUserClass(){
-        return this.userModelClass;
+    public Class<T> getUserClass(){
+        return this.userModelClass != null ? this.userModelClass : BaseUser.class;
     }
 
     public Class getUserArrayClass(){
-        return Array.newInstance(userModelClass, 0).getClass();
+        return Array.newInstance(getUserClass(), 0).getClass();
     }
 
-    public void setUserClass(Class userClass){
+    public void setUserClass(Class<T> userClass){
         this.userModelClass = userClass;
     }
 

--- a/java-api-core/src/com/kinvey/java/AbstractClient.java
+++ b/java-api-core/src/com/kinvey/java/AbstractClient.java
@@ -83,7 +83,7 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
     private ArrayList<ClientExtension> extensions;
 
     /** Class to use for representing a BaseUser **/
-    private Class userModelClass = null;
+    private Class<T> userModelClass = (Class<T>) BaseUser.class;
     
     private String clientAppVersion = null;
     
@@ -561,7 +561,7 @@ public abstract class AbstractClient<T extends BaseUser> extends AbstractKinveyJ
     }
 
     public Class<T> getUserClass(){
-        return this.userModelClass != null ? this.userModelClass : BaseUser.class;
+        return userModelClass;
     }
 
     public Class getUserArrayClass(){

--- a/java-api-core/src/com/kinvey/java/auth/Credential.java
+++ b/java-api-core/src/com/kinvey/java/auth/Credential.java
@@ -16,9 +16,12 @@
 
 package com.kinvey.java.auth;
 
+import com.google.api.client.json.GenericJson;
 import com.kinvey.java.core.AbstractKinveyClientRequest;
 import com.kinvey.java.core.KinveyRequestInitializer;
 import com.kinvey.java.dto.BaseUser;
+
+import java.util.Map;
 
 /**
  * @author m0rganic
@@ -29,6 +32,8 @@ public class Credential implements KinveyRequestInitializer, java.io.Serializabl
     private static final long serialVersionUID = 1L;
 
     private final static String AUTH_N_HEADER_FORMAT = "Kinvey %s";
+    private final static String AUTH_TOKEN = "authtoken";
+    private final static String KMD = "_kmd";
 
     private String userId;
 
@@ -61,11 +66,25 @@ public class Credential implements KinveyRequestInitializer, java.io.Serializabl
      * @return a newly constructed Credential object
      */
     public static Credential from(KinveyAuthResponse response){
-        return new Credential(response.getUserId(), response.getAuthToken(), null);
+        return from(response.getUserId(), response.getAuthToken());
     }
 
+    /**
+     * @param baseUser authorised user for saving auth token
+     * @return a newly constructed Credential object
+     */
     public static Credential from(BaseUser baseUser){
-        return new Credential(baseUser.getId(), baseUser.get("authToken").toString(), null);
+        Map<String, String> kmd = (Map<String, String>)baseUser.get(KMD);
+        return from(baseUser.getId(), kmd != null ? kmd.get(AUTH_TOKEN) : null);
+    }
+
+    /**
+     * @param userId user id for saving
+     * @param authToken authToken for saving
+     * @return a newly constructed Credential object
+     */
+    public static Credential from(String userId, String authToken){
+        return new Credential(userId, authToken, null);
     }
 
     public String getUserId() {

--- a/java-api-core/src/com/kinvey/java/auth/CredentialManager.java
+++ b/java-api-core/src/com/kinvey/java/auth/CredentialManager.java
@@ -16,6 +16,8 @@
 
 package com.kinvey.java.auth;
 
+import com.kinvey.java.dto.BaseUser;
+
 import java.io.IOException;
 
 /**
@@ -76,6 +78,19 @@ public class CredentialManager {
             credentialStore.store(userId, newCredential);
         }
 
+        return newCredential;
+    }
+
+    /**
+     * @param baseUser user
+     * @return new credential object
+     */
+    public Credential createAndStoreCredential (BaseUser baseUser) throws IOException {
+        String userId = baseUser.getId();
+        Credential newCredential = Credential.from(baseUser);
+        if (userId != null && credentialStore != null) {
+            credentialStore.store(userId, newCredential);
+        }
         return newCredential;
     }
 

--- a/java-api-core/src/com/kinvey/java/auth/KinveyAuthRequest.java
+++ b/java-api-core/src/com/kinvey/java/auth/KinveyAuthRequest.java
@@ -38,12 +38,13 @@ import java.util.Locale;
 import com.kinvey.java.Logger;
 import com.kinvey.java.core.KinveyHeaders;
 import com.kinvey.java.core.KinveyJsonResponseException;
+import com.kinvey.java.dto.BaseUser;
 
 /**
  * @author m0rganic
  * @since 2.0
  */
-public class KinveyAuthRequest extends GenericJson {
+public class KinveyAuthRequest<T extends BaseUser> extends GenericJson {
 
 
     public enum LoginType {
@@ -225,6 +226,9 @@ public class KinveyAuthRequest extends GenericJson {
         return executeUnparsed().parseAs(KinveyAuthResponse.class);
     }
 
+    public T execute(Class<T> aClass) throws IOException {
+        return executeUnparsed().parseAs(aClass);
+    }
 
 
     /**
@@ -267,7 +271,7 @@ public class KinveyAuthRequest extends GenericJson {
      *              .execute();
      * </pre>
      */
-    public static class Builder {
+    public static class Builder<T extends BaseUser> {
 
         private final HttpTransport transport;
 
@@ -312,15 +316,15 @@ public class KinveyAuthRequest extends GenericJson {
             this.thirdPartyIdentity = identity;
         }
 
-        public KinveyAuthRequest build() {
+        public KinveyAuthRequest<T> build() {
             if (!isThirdPartyAuthUsed) {
-                return new KinveyAuthRequest(getTransport()
+                return new KinveyAuthRequest<>(getTransport()
                         , getJsonFactory()
                         , getBaseUrl(), getAppKeyAuthentication()
                         , getUsername()
                         , getPassword(),user, this.create);
             }
-            return new KinveyAuthRequest(getTransport()
+            return new KinveyAuthRequest<>(getTransport()
                     , getJsonFactory()
                     , getBaseUrl(), getAppKeyAuthentication()
                     , getThirdPartyIdentity(),user, this.create);

--- a/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseUserStore.java
@@ -15,134 +15,134 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public abstract class BaseUserStore <T extends BaseUser> {
+public abstract class BaseUserStore {
 
-    public static <T extends BaseUser> T signUp(String userId, String password, T user, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).createBlocking(userId, password, user).execute();
+    public static <T extends BaseUser> T signUp(String userId, String password, T user, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).createBlocking(userId, password, user).execute();
     }
 
-    public static <T extends BaseUser> T signUp(String userId, String password, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).createBlocking(userId, password).execute();
+    public static <T extends BaseUser> T signUp(String userId, String password, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).createBlocking(userId, password).execute();
     }
 
     /*Deletes a 'BaseUser'*/
-    public static  void destroy(boolean isHard, AbstractClient client) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).deleteBlocking(isHard).execute();
+    public static <T extends BaseUser>  void destroy(boolean isHard, AbstractClient<T> client) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).deleteBlocking(isHard).execute();
     }
 
     public static  <T extends BaseUser> T login(String username, String password,
-                                                AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+                                                AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginBlocking(username, password).execute();
     }
 
-    public static  <T extends BaseUser> T login(AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+    public static  <T extends BaseUser> T login(AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginBlocking().execute();
     }
 
-    public static <T extends BaseUser> T loginFacebook(String accessToken, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+    public static <T extends BaseUser> T loginFacebook(String accessToken, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginFacebookBlocking(accessToken).execute();
     }
 
-    public static <T extends BaseUser> T loginGoogle(String accessToken, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+    public static <T extends BaseUser> T loginGoogle(String accessToken, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginGoogleBlocking(accessToken).execute();
     }
 
     public static <T extends BaseUser> T loginTwitter(String accessToken, String accessSecret, String consumerKey,
-                                                      String consumerSecret, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).
+                                                      String consumerSecret, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).
                 loginTwitterBlocking(accessToken, accessSecret, consumerKey, consumerSecret).execute();
     }
 
     public static <T extends BaseUser> T loginLinkedIn(String accessToken, String accessSecret, String consumerKey,
-                                                       String consumerSecret, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+                                                       String consumerSecret, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginLinkedInBlocking(accessToken, accessSecret, consumerKey, consumerSecret).execute();
     }
 
     public static <T extends BaseUser> T loginAuthLink(String accessToken, String refreshToken,
-                                                       AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+                                                       AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginAuthLinkBlocking(accessToken, refreshToken).execute();
     }
 
     public static <T extends BaseUser> T loginSalesForce(String accessToken, String clientId,
                                                          String refreshToken, String id,
-                                                         AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+                                                         AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginSalesForceBlocking(accessToken, clientId, refreshToken, id).execute();
     }
 
-    public static <T extends BaseUser> T loginMobileIdentity(String authToken, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client))
+    public static <T extends BaseUser> T loginMobileIdentity(String authToken, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client))
                 .loginMobileIdentityBlocking(authToken).execute();
     }
 
-    public static <T extends BaseUser> T login(Credential credential, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).login(credential).execute();
+    public static <T extends BaseUser> T login(Credential credential, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).login(credential).execute();
     }
 
-    public static <T extends BaseUser> T loginKinveyAuthToken(String userId, String authToken, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).loginKinveyAuthTokenBlocking(userId, authToken).execute();
+    public static <T extends BaseUser> T loginKinveyAuthToken(String userId, String authToken, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).loginKinveyAuthTokenBlocking(userId, authToken).execute();
     }
 
-    public static void logout(AbstractClient client) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).logout().execute();
+    public static <T extends BaseUser> void logout(AbstractClient<T> client) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).logout().execute();
     }
 
-    public static void sendEmailConfirmation(AbstractClient client) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).sendEmailVerificationBlocking().execute();
+    public static <T extends BaseUser> void sendEmailConfirmation(AbstractClient<T> client) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).sendEmailVerificationBlocking().execute();
     }
 
-    public static void resetPassword(String usernameOrEmail, AbstractClient client) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).resetPasswordBlocking(usernameOrEmail).execute();
+    public static<T extends BaseUser> void resetPassword(String usernameOrEmail, AbstractClient<T> client) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).resetPasswordBlocking(usernameOrEmail).execute();
     }
 
-    public static void changePassword(String password, AbstractClient client) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).changePassword(password).execute();
+    public static <T extends BaseUser> void changePassword(String password, AbstractClient<T> client) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).changePassword(password).execute();
     }
 
-    public static <T extends BaseUser> T convenience(AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).retrieveMetadataBlocking();
+    public static <T extends BaseUser> T convenience(AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).retrieveMetadataBlocking();
     }
 
-    public static <T extends BaseUser> T retrieve(AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).retrieveBlocking().execute();
+    public static <T extends BaseUser> T retrieve(AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).retrieveBlocking().execute();
     }
 
-    public static <T extends BaseUser> List<T> retrieve(Query query, AbstractClient client) throws IOException {
-        return new ArrayList<T>(Arrays.asList((T[]) new UserStoreRequestManager(client, createBuilder(client)).retrieveBlocking(query).execute()));
+    public static <T extends BaseUser> List<T> retrieve(Query query, AbstractClient<T> client) throws IOException {
+        return new ArrayList<>(Arrays.asList((T[]) new UserStoreRequestManager<>(client, createBuilder(client)).retrieveBlocking(query).execute()));
     }
 
-    public static <T extends BaseUser> T retrieve(String[] resolves, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).retrieveBlocking(resolves).execute();
+    public static <T extends BaseUser> T retrieve(String[] resolves, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).retrieveBlocking(resolves).execute();
     }
 
-    public static <T extends BaseUser> List<T> retrieve(Query query, String[] resolves, AbstractClient client) throws IOException {
-        return new ArrayList<T>(Arrays.asList((T[]) new UserStoreRequestManager(client, createBuilder(client)).retrieveBlocking(query, resolves).execute()));
+    public static <T extends BaseUser> List<T> retrieve(Query query, String[] resolves, AbstractClient<T> client) throws IOException {
+        return new ArrayList<>(Arrays.asList((T[]) new UserStoreRequestManager<>(client, createBuilder(client)).retrieveBlocking(query, resolves).execute()));
     }
 
-    public static void forgotUsername(AbstractClient client, String email) throws IOException {
-        new UserStoreRequestManager(client, createBuilder(client)).forgotUsername(email).execute();
+    public static <T extends BaseUser> void forgotUsername(AbstractClient<T> client, String email) throws IOException {
+        new UserStoreRequestManager<>(client, createBuilder(client)).forgotUsername(email).execute();
     }
 
-    public static boolean exists( String username, AbstractClient client) throws IOException {
-        return new UserStoreRequestManager(client, createBuilder(client)).exists(username).execute().doesUsernameExist();
+    public static <T extends BaseUser> boolean exists( String username, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).exists(username).execute().doesUsernameExist();
     }
 
-    public static <T extends BaseUser> T get(String userId, AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).getUser(userId).execute();
+    public static <T extends BaseUser> T get(String userId, AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).getUser(userId).execute();
     }
 
-    public static <T extends BaseUser> T save(AbstractClient client) throws IOException {
-        return (T) new UserStoreRequestManager(client, createBuilder(client)).save().execute();
+    public static <T extends BaseUser> T save(AbstractClient<T> client) throws IOException {
+        return new UserStoreRequestManager<>(client, createBuilder(client)).save().execute();
     }
 
     public static <T extends BaseUser> T update() throws IOException {
-        return (T) new UserStoreRequestManager(AbstractClient.sharedInstance(), createBuilder(AbstractClient.sharedInstance())).save().execute();
+        return new UserStoreRequestManager<T>(AbstractClient.sharedInstance(), createBuilder(AbstractClient.sharedInstance())).save().execute();
     }
 
     /**
@@ -177,18 +177,18 @@ public abstract class BaseUserStore <T extends BaseUser> {
         }
         if (LiveServiceRouter.getInstance().isInitialized()) {
             LiveServiceRouter.getInstance().uninitialize();
-            new UserStoreRequestManager(AbstractClient.sharedInstance(),
+            new UserStoreRequestManager<>(AbstractClient.sharedInstance(),
                     createBuilder(AbstractClient.sharedInstance()))
                     .liveServiceUnregister(AbstractClient.sharedInstance().getActiveUser().getId(),
                             AbstractClient.sharedInstance().getDeviceId()).execute();
         }
     }
 
-    private static KinveyAuthRequest.Builder createBuilder(AbstractClient client) {
+    private static <T extends BaseUser> KinveyAuthRequest.Builder<T> createBuilder(AbstractClient<T> client) {
         String appKey = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppKey();
         String appSecret = ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer()).getAppSecret();
 
-        return new KinveyAuthRequest.Builder(client.getRequestFactory().getTransport(),
+        return new KinveyAuthRequest.Builder<>(client.getRequestFactory().getTransport(),
                 client.getJsonFactory(), client.getBaseUrl(), appKey, appSecret, null);
     }
 

--- a/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
+++ b/java-api-core/src/com/kinvey/java/store/UserStoreRequestManager.java
@@ -83,8 +83,8 @@ public class UserStoreRequestManager<T extends BaseUser> {
         THIRDPARTY
     }
 
-    private final AbstractClient client;
-    private final KinveyAuthRequest.Builder builder;
+    private final AbstractClient<T> client;
+    private final KinveyAuthRequest.Builder<T> builder;
     private final Class<T> myClazz;
     private T user;
     private final String clientAppVersion;
@@ -117,7 +117,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
         return client;
     }
 
-    public UserStoreRequestManager(AbstractClient client, KinveyAuthRequest.Builder builder){
+    public UserStoreRequestManager(AbstractClient<T> client, KinveyAuthRequest.Builder<T> builder){
         Preconditions.checkNotNull(client, "client must not be null.");
         Preconditions.checkNotNull(builder, "KinveyAuthRequest.Builder should not be null");
         this.client = client;
@@ -128,7 +128,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
         this.customRequestProperties = client.getCustomRequestProperties();
     }
 
-    public UserStoreRequestManager(T user, AbstractClient client, KinveyAuthRequest.Builder builder){
+    public UserStoreRequestManager(T user, AbstractClient client, KinveyAuthRequest.Builder<T> builder){
         this(client, builder);
         this.user = user;
     }
@@ -139,7 +139,9 @@ public class UserStoreRequestManager<T extends BaseUser> {
      *
      * @param response KinveyAuthResponse object containing the login response
      * @throws IOException
+     * @deprecated use {@link UserStoreRequestManager#initUser(BaseUser)} instead.
      */
+    @Deprecated
     public T initUser(KinveyAuthResponse response, T userObject) throws IOException {
         userObject.setId(response.getUserId());
         userObject.put("_kmd", response.getMetadata());
@@ -168,6 +170,22 @@ public class UserStoreRequestManager<T extends BaseUser> {
         client.getClientUser().setUser(currentUser.getId());
         client.setActiveUser(currentUser);
         return currentUser;
+    }
+
+    /**
+     * Method to initialize the BaseUser after login, create a credential,
+     * and add it to the KinveyClientRequestInitializer
+     *
+     * @param userObject user object for setting to active user and to save to Credential
+     * @throws IOException exception
+     */
+    public T initUser(final T userObject) throws IOException {
+        CredentialManager credentialManager = new CredentialManager(client.getStore());
+        ((KinveyClientRequestInitializer) client.getKinveyRequestInitializer())
+                .setCredential(credentialManager.createAndStoreCredential(userObject));
+        client.getClientUser().setUser(userObject.getId());
+        client.setActiveUser(userObject);
+        return userObject;
     }
 
     private T initUser(Credential credential, T userObject) {
@@ -339,7 +357,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
         }
         currentUser.setAuthToken(authToken);
         currentUser.setId(userId);
-        Credential c = Credential.from(currentUser);
+        Credential c = Credential.from(userId, authToken);
         client.setActiveUser(currentUser);
         return login(c);
 
@@ -499,10 +517,10 @@ public class UserStoreRequestManager<T extends BaseUser> {
      * @return Update request
      * @throws IOException
      */
-    public Update updateBlocking() throws IOException{
+    public Update<T> updateBlocking() throws IOException{
         Preconditions.checkNotNull(client.getActiveUser(), "currentUser must not be null");
         Preconditions.checkNotNull(client.getActiveUser().getId(), "currentUser ID must not be null");
-        Update update = new Update(this, client.getActiveUser());
+        Update<T> update = new Update<>(this, client.getActiveUser(), myClazz);
         client.initializeRequest(update);
         return update;
     }
@@ -514,20 +532,20 @@ public class UserStoreRequestManager<T extends BaseUser> {
      * @return an Update request ready to be executed
      * @throws IOException
      */
-    public Update updateBlocking(BaseUser baseUser) throws IOException{
+    public Update<T> updateBlocking(BaseUser baseUser) throws IOException{
         Preconditions.checkNotNull(baseUser, "currentUser must not be null");
         Preconditions.checkNotNull(baseUser.getId(), "currentUser ID must not be null");
-        Update update = new Update(this, baseUser);
+        Update<T> update = new Update<>(this, baseUser, myClazz);
         client.initializeRequest(update);
         return update;
     }
 
-    public Update changePassword(String newPassword) throws IOException{
+    public Update<T> changePassword(String newPassword) throws IOException{
         Preconditions.checkNotNull(client.getActiveUser(), "currentUser must not be null");
         Preconditions.checkNotNull(client.getActiveUser().getId(), "currentUser ID must not be null");
         PasswordRequest passwordRequest = new PasswordRequest();
         passwordRequest.setPassword(newPassword);
-        Update update = new Update(this, client.getActiveUser(), passwordRequest);
+        Update<T> update = new Update<>(this, client.getActiveUser(), passwordRequest, myClazz);
         client.initializeRequest(update);
         return update;
     }
@@ -541,14 +559,14 @@ public class UserStoreRequestManager<T extends BaseUser> {
         return userExists;
     }
 
-    public Update getUser(String userId) throws IOException {
+    public Update<T> getUser(String userId) throws IOException {
         Preconditions.checkNotNull(userId, "username must not be null");
-        Update update = new Update(this, userId);
+        Update<T> update = new Update<>(this, userId, myClazz);
         client.initializeRequest(update);
         return update;
     }
 
-    public Update save() throws IOException {
+    public Update<T> save() throws IOException {
         return updateBlocking();
     }
 
@@ -716,7 +734,7 @@ public class UserStoreRequestManager<T extends BaseUser> {
     public class LoginRequest {
         Credential credential;
         UserStoreRequestManager.LoginType type;
-        KinveyAuthRequest request;
+        KinveyAuthRequest<T> request;
 
         public LoginRequest() {
             builder.setCreate(true);
@@ -761,19 +779,19 @@ public class UserStoreRequestManager<T extends BaseUser> {
                         "call `UserStore.logout(myClient, kinveyClientCallback)` first -or- check `myClient.isUserLoggedIn()` before attempting to login again",
                         "Only one user can be active at a time, and logging in a new user will replace the current user which might not be intended");
             }
-            T ret;
+            T loggedUser;
             try {
-                ret = myClazz.newInstance();
+                loggedUser = myClazz.newInstance();
             } catch (Exception e) {
 //                e.printStackTrace();
                 throw new NullPointerException(e.getMessage());
             }
             if (this.type == UserStoreRequestManager.LoginType.CREDENTIALSTORE) {
-                return initUser(credential, ret);
+                return initUser(credential, loggedUser);
             }
-            KinveyAuthResponse response = this.request.execute();
+            loggedUser = this.request.execute(myClazz);
             //if (response.)
-            return initUser(response, ret);
+            return initUser(loggedUser);
         }
     }
 

--- a/java-api-core/src/com/kinvey/java/store/requests/user/Update.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/user/Update.java
@@ -16,10 +16,8 @@
 
 package com.kinvey.java.store.requests.user;
 
-import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.Key;
 import com.google.gson.Gson;
-import com.kinvey.java.auth.KinveyAuthResponse;
 import com.kinvey.java.core.AbstractKinveyJsonClientRequest;
 import com.kinvey.java.dto.BaseUser;
 import com.kinvey.java.dto.PasswordRequest;
@@ -31,15 +29,15 @@ import java.io.IOException;
  * Update Request Class, extends AbstractKinveyJsonClientRequest<BaseUser>.  Constructs the HTTP request object for
  * Update BaseUser requests.
  */
-public final class Update extends AbstractKinveyJsonClientRequest<BaseUser> {
+public final class Update<T extends BaseUser> extends AbstractKinveyJsonClientRequest<T> {
     private static final String REST_PATH = "user/{appKey}/{userID}";
 
-    private UserStoreRequestManager userStoreRequestManager;
+    private UserStoreRequestManager<T> userStoreRequestManager;
     @Key
     private String userID;
 
-    public Update(UserStoreRequestManager userStoreRequestManager, BaseUser baseUser) {
-        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, baseUser, BaseUser.class);
+    public Update(UserStoreRequestManager<T> userStoreRequestManager, BaseUser baseUser, Class<T> userClass) {
+        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, baseUser, userClass);
         this.userStoreRequestManager = userStoreRequestManager;
         this.userID = baseUser.getId();
         this.getRequestHeaders().put("X-Kinvey-Client-App-Version", userStoreRequestManager.getClientAppVersion());
@@ -48,8 +46,8 @@ public final class Update extends AbstractKinveyJsonClientRequest<BaseUser> {
         }
     }
 
-    public Update(UserStoreRequestManager userStoreRequestManager, BaseUser baseUser, PasswordRequest passwordRequest) {
-        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, passwordRequest, BaseUser.class);
+    public Update(UserStoreRequestManager<T> userStoreRequestManager, BaseUser baseUser, PasswordRequest passwordRequest, Class<T> userClass) {
+        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, passwordRequest, userClass);
         this.userStoreRequestManager = userStoreRequestManager;
         this.userID = baseUser.getId();
         this.getRequestHeaders().put("X-Kinvey-Client-App-Version", userStoreRequestManager.getClientAppVersion());
@@ -58,8 +56,8 @@ public final class Update extends AbstractKinveyJsonClientRequest<BaseUser> {
         }
     }
 
-    public Update(UserStoreRequestManager userStoreRequestManager, String userId) {
-        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, null, BaseUser.class);
+    public Update(UserStoreRequestManager<T> userStoreRequestManager, String userId, Class<T> userClass) {
+        super(userStoreRequestManager.getClient(), "PUT", REST_PATH, null, userClass);
         this.userStoreRequestManager = userStoreRequestManager;
         this.userID = userId;
         this.getRequestHeaders().put("X-Kinvey-Client-App-Version", userStoreRequestManager.getClientAppVersion());
@@ -68,31 +66,19 @@ public final class Update extends AbstractKinveyJsonClientRequest<BaseUser> {
         }
     }
 
-    public BaseUser execute() throws IOException {
+    @Override
+    public T execute() throws IOException {
 
-        BaseUser u = super.execute();
+        T updatedUser = super.execute();
 
-        if (u.getId() == null || u.getId() == null){
-            return u;
+        if (updatedUser.getId() == null || updatedUser.getId() == null){
+            return updatedUser;
         }
 
-        if (u.getId().equals(userID)){
-            KinveyAuthResponse auth = new KinveyAuthResponse();
-            auth.put("_id", u.get("_id"));
-            KinveyAuthResponse.KinveyUserMetadata kmd = new KinveyAuthResponse.KinveyUserMetadata();
-            kmd.put("lmt", u.get("_kmd.lmt")) ;
-            kmd.put("authtoken", u.get("_kmd.authtoken"));
-            kmd.putAll((ArrayMap) u.get("_kmd"));
-            auth.put("_kmd", kmd);
-            auth.put("username", u.get("username"));
-            for (Object key : u.keySet()){
-                if (!key.toString().equals("_kmd")){
-                    auth.put(key.toString(), u.get(key));
-                }
-            }
-            return userStoreRequestManager.initUser(auth, u);
-        }else{
-            return u;
+        if (updatedUser.getId().equals(userID)) {
+            return userStoreRequestManager.initUser(updatedUser);
+        } else {
+            return updatedUser;
         }
     }
 }

--- a/java-api-core/test/com/kinvey/java/BaseUserTest.java
+++ b/java-api-core/test/com/kinvey/java/BaseUserTest.java
@@ -39,13 +39,13 @@ import com.kinvey.java.testing.MockKinveyAuthRequest;
  */
 public class BaseUserTest extends KinveyMockUnitTest {
 
-    private UserStoreRequestManager requestManager;
+    private UserStoreRequestManager<BaseUser> requestManager;
     private static final String X_KINVEY_CUSTOM_REQUEST_PROPERTIES = "X-Kinvey-Custom-Request-Properties";
     private static final String X_KINVEY_CLIENT_APP_VERSION = "X-Kinvey-Client-App-Version";
     private static final String USER_ID = "userID";
 
     private void initializeRequestManager(boolean isNeedCreateUser) {
-        requestManager = new UserStoreRequestManager(getClient(), new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
+        requestManager = new UserStoreRequestManager<>(getClient(), new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
                 getClient().getJsonFactory(), "mockAppKey","mockAppSecret", null));
         if (isNeedCreateUser) {
             requestManager.getClient().setActiveUser(new BaseUser());
@@ -53,7 +53,7 @@ public class BaseUserTest extends KinveyMockUnitTest {
     }
 
     public void testInitializeUser() {
-        UserStoreRequestManager user = new UserStoreRequestManager(getClient(), new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
+        UserStoreRequestManager<BaseUser> user = new UserStoreRequestManager<>(getClient(), new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
                 getClient().getJsonFactory(), "mockAppKey","mockAppSecret",null));
         assertNotNull(user);
         assertEquals(getClient(),user.getClient());
@@ -62,7 +62,7 @@ public class BaseUserTest extends KinveyMockUnitTest {
 
     public void testInitializeUserNullClient() {
         try {
-            UserStoreRequestManager user = new UserStoreRequestManager(null, new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
+            UserStoreRequestManager<BaseUser> user = new UserStoreRequestManager<>(null, new MockKinveyAuthRequest.MockBuilder(getClient().getRequestFactory().getTransport(),
                     getClient().getJsonFactory(), "mockAppKey","mockAppSecret",null));
             fail("NullPointerException should be thrown");
         } catch (NullPointerException ex) {}
@@ -291,7 +291,7 @@ public class BaseUserTest extends KinveyMockUnitTest {
 
     public void testMICLoginWithAccessToken() throws IOException{
 
-    	requestManager = new UserStoreRequestManager(getClient(new MockHttpForMIC()), new KinveyAuthRequest.Builder(new MockHttpForMIC(),
+    	requestManager = new UserStoreRequestManager<>(getClient(new MockHttpForMIC()), new KinveyAuthRequest.Builder<>(new MockHttpForMIC(),
                 new GsonFactory(),"https://baas.kinvey.com",  "mockAppKey","mockAppSecret",null));
 
     	GetMICAccessToken token = requestManager.getMICToken("MyToken", null);

--- a/java-api-core/test/com/kinvey/java/core/KinveyMockUnitTest.java
+++ b/java-api-core/test/com/kinvey/java/core/KinveyMockUnitTest.java
@@ -40,18 +40,18 @@ import com.kinvey.java.query.MongoQueryFilter;
  * @author edwardf
  * @since 2.0
  */
-public abstract class KinveyMockUnitTest extends TestCase {
+public abstract class KinveyMockUnitTest<T extends BaseUser> extends TestCase {
 
-    private MockTestClient mockClient;
+    private MockTestClient<T> mockClient;
         
-    public MockTestClient getClient(){
+    public MockTestClient<T> getClient(){
     	if (mockClient == null){
     		mockClient = new MockTestClient.Builder(new MockHttpTransport(),new MockJsonFactory(), null, new MockKinveyClientRequestInitializer()).build();
     	}
     	return mockClient;
     }
     
-    public MockTestClient getClient(HttpTransport transport){
+    public MockTestClient<T> getClient(HttpTransport transport){
     	return new MockTestClient.Builder(transport, new GsonFactory(), null, new MockKinveyClientRequestInitializer()).build();
     }
 
@@ -62,7 +62,7 @@ public abstract class KinveyMockUnitTest extends TestCase {
         return (KinveyClientRequestInitializer) mockClient.getKinveyRequestInitializer();
     }
 
-    protected static class MockTestClient extends AbstractClient {
+    protected static class MockTestClient<T extends BaseUser> extends AbstractClient<T> {
 
         private ConcurrentHashMap<String, NetworkManager> appDataInstanceCache;
 
@@ -112,14 +112,14 @@ public abstract class KinveyMockUnitTest extends TestCase {
         }
 
         @Override
-        public void setActiveUser(BaseUser user) {
+        public void setActiveUser(T user) {
             synchronized (lock) {
                 this.user = user;
             }
         }
 
         @Override
-        public BaseUser getActiveUser() {
+        public T getActiveUser() {
             synchronized (lock) {
                 return this.user;
             }


### PR DESCRIPTION
#### Description
Extending user class with properties of different class cause an exception

#### Changes
Updated auth response parsing. Now the SDK gets user class as a model for response parsing. Previously the model for response parsing had only `id` and `_kmd` fields, other primitive fields were got as fields from GenericJson and it didn't work for GenericJson fields in the user model class.

#### Tests
Instrumented