### PR TITLE
feat: MLIBZ-2563 Add updating query cache item if it exists instead of creating new

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaSetNewTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DeltaSetNewTest.java
@@ -1274,4 +1274,23 @@ public class DeltaSetNewTest {
         assertEquals(5, pullCallback.getResult().getCount());
         assertEquals(5, testManager.find(store, emptyQuery).getResult().getResult().size());
     }
+
+    @Test
+    public void testDeltaSetDoRequestAfter2FailedAttempts() throws IOException, InterruptedException {
+        DataStore<Person> networkStore = DataStore.collection(Person.DELTA_SET_OFF_COLLECTION, Person.class, StoreType.NETWORK, client);
+        testManager.cleanBackend(networkStore, StoreType.NETWORK);
+        store = DataStore.collection(Person.DELTA_SET_OFF_COLLECTION, Person.class, StoreType.SYNC, client);
+        store.setDeltaSetCachingEnabled(true);
+        testManager.createPersons(networkStore, 2);
+        CustomKinveyPullCallback pullCallback = testManager.pullCustom(store, client.query());
+        assertEquals(2, pullCallback.getResult().getCount());
+        ICache<QueryCacheItem> queryCache = client.getSyncManager().getCacheManager().getCache(Constants.QUERY_CACHE_COLLECTION, QueryCacheItem.class, Long.MAX_VALUE);
+        assertEquals(1, queryCache.get().size());
+        pullCallback = testManager.pullCustom(store, client.query());
+        assertEquals(2, pullCallback.getResult().getCount());
+        assertEquals(1, queryCache.get().size());
+        pullCallback = testManager.pullCustom(store, client.query());
+        assertEquals(2, pullCallback.getResult().getCount());
+        assertEquals(1, queryCache.get().size());
+    }
 }

--- a/java-api-core/src/com/kinvey/java/Constants.java
+++ b/java-api-core/src/com/kinvey/java/Constants.java
@@ -8,6 +8,7 @@ public final class Constants {
     public static final String COLLECTION = "collection";
     public static final String UNDERSCORE = "_";
     public static final String TIME_FORMAT = "%tFT%<tTZ";
+    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
     public static final String Z = "Z";
     public static final String DOT = ".";
     public static final String QUERY = "query";


### PR DESCRIPTION
#### Description
When a deltaset specific error occurs, deltaset request is not retried on next attempts to pull/sync
Steps to reproduce:

1. Disable deltaset at the backend
2. Pull
3. Pull
4. Pull

Expected result: The first pull makes a regular GET and enter a value in the _QueryCache table, the next one attempts _deltaset request, but it fails for an error, so a regular GET is again made and its value overrides the lastRequestAt value in the _QueryCache table. The third request does exactly the same as the second one

Actual result: The first pull does what is expected, the second uses deltaset and then regular GET, but records a new entry for the query in _QueryCache table, so now it has 2 entries. The third pull directly makes a regular GET instead of first using deltaset. These also make their own entries on the _QueryCache, so after a few pulls, there are a few entries with the same query but with different lastRunAt values.

#### Changes
Added updating the query cache item if it exists instead of creating new.
Added checking that the query cache has only 1 item for the query, else  all items(with the same query) is deleted except the latest one.

#### Tests
Instrumented
