### PR TITLE
feat: MLIBZ-2472 Using 'int' primitive type in class model and store SYNC and CACHE throws an exception

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/Person.java
@@ -37,6 +37,9 @@ public class Person extends GenericJson{
     private long weight ;
 
     @Key
+    private int intVal ;
+
+    @Key
     private Integer carNumber ;
 
     @Key("username")
@@ -96,5 +99,13 @@ public class Person extends GenericJson{
 
     public void setAuthor(Author author) {
         this.author = author;
+    }
+
+    public int getIntVal() {
+        return intVal;
+    }
+
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
     }
 }

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -817,7 +817,7 @@ public abstract class ClassHash {
                 }
 
                 if (Number.class.isAssignableFrom(info.getType())){
-                    Number n = (Number)dynamic.get(info.getName());
+                    Number n = dynamic.get(info.getName());
                     if (Long.class.isAssignableFrom(info.getType())){
                         ret.put(info.getName(), n.longValue());
                     } else if (Byte.class.isAssignableFrom(info.getType())){
@@ -860,8 +860,13 @@ public abstract class ClassHash {
                             ret.put(info.getName(), c);
                         }
                     }
-                } else {
-                    ret.put(info.getName(), o);
+                } else { //if you are here, then the field is a primitive
+                    // realm keeps int values as a long, so we need to convert it back
+                    if (info.getType().isPrimitive() && info.getType().getSimpleName().equals("int") && o instanceof Long) {
+                        ret.put(info.getName(), ((Long) o).intValue());
+                    } else {
+                        ret.put(info.getName(), o);
+                    }
                 }
 
             }


### PR DESCRIPTION
#### Description
 Using 'int' primitive type in class model and store SYNC and CACHE throws an exception

#### Changes
Added сonverting long to int type when the SDK gets an object from the realm file

#### Tests
Instrumented
