### PR TITLE
feat: MLIBZ-2558 Change how sync queue stores request information

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/TempIdTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/TempIdTest.java
@@ -1,0 +1,199 @@
+package com.kinvey.androidTest.cache;
+
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.RenamingDelegatingContext;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.kinvey.android.Client;
+import com.kinvey.android.store.DataStore;
+import com.kinvey.androidTest.TestManager;
+import com.kinvey.androidTest.callback.DefaultKinveyClientCallback;
+import com.kinvey.androidTest.callback.DefaultKinveyReadCallback;
+import com.kinvey.androidTest.model.Person;
+import com.kinvey.java.Constants;
+import com.kinvey.java.Query;
+import com.kinvey.java.cache.ICache;
+import com.kinvey.java.core.KinveyJsonError;
+import com.kinvey.java.core.KinveyJsonResponseException;
+import com.kinvey.java.network.NetworkManager;
+import com.kinvey.java.store.BaseDataStore;
+import com.kinvey.java.store.QueryCacheItem;
+import com.kinvey.java.store.StoreType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.UUID;
+
+import static com.kinvey.androidTest.TestManager.PASSWORD;
+import static com.kinvey.androidTest.TestManager.TEST_USERNAME;
+import static com.kinvey.androidTest.TestManager.TEST_USERNAME_2;
+import static com.kinvey.androidTest.TestManager.USERNAME;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class TempIdTest {
+
+    private static final String TEMP_ID = "temp_";
+    private Client client;
+    private TestManager<Person> testManager;
+    private DataStore<Person> store;
+
+    @Before
+    public void setUp() throws InterruptedException {
+        Context mMockContext = new RenamingDelegatingContext(InstrumentationRegistry.getInstrumentation().getTargetContext(), "test_");
+        client = new Client.Builder(mMockContext).build();
+        testManager = new TestManager<>();
+        testManager.login(USERNAME, PASSWORD, client);
+    }
+
+    @After
+    public void tearDown() {
+        client.performLockDown();
+        if (client.getKinveyHandlerThread() != null) {
+            try {
+                client.stopKinveyHandlerThread();
+            } catch (Throwable throwable) {
+                throwable.printStackTrace();
+            }
+        }
+    }
+
+    /* check that temp item is created with 'temp_' prefix for local keeping and after pushing, item id is updated */
+    @Test
+    public void testCreatingPrefixForTempId() throws  InterruptedException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        Person person = new Person(TEST_USERNAME);
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person);
+        assertNotNull(saveCallback);
+        assertNull(saveCallback.getError());
+        assertNotNull(saveCallback.getResult());
+        Person savedPerson = saveCallback.getResult();
+        assertTrue(savedPerson.getId().startsWith(TEMP_ID));
+        DefaultKinveyReadCallback readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        Person fromCache = readCallback.getResult().getResult().get(0);
+        assertTrue(fromCache.getId().startsWith(TEMP_ID));
+        assertEquals(savedPerson.getId(), fromCache.getId());
+        testManager.push(store);
+        readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        fromCache = readCallback.getResult().getResult().get(0);
+        assertFalse(fromCache.getId().startsWith(TEMP_ID));
+        assertNotEquals(savedPerson.getId(), fromCache.getId());
+        assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
+    }
+
+    /* check that old temp item which was created without 'temp_' prefix for local keeping will be pushed as expect */
+    @Test
+    public void testBackwardCompatibility() throws  InterruptedException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        Person person = new Person(TEST_USERNAME);
+        person.setId(UUID.randomUUID().toString());
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person);
+        assertNotNull(saveCallback);
+        assertNull(saveCallback.getError());
+        assertNotNull(saveCallback.getResult());
+        Person savedPerson = saveCallback.getResult();
+        assertFalse(savedPerson.getId().startsWith(TEMP_ID));
+        assertEquals(person.getId(), savedPerson.getId());
+        DefaultKinveyReadCallback readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        Person fromCache = readCallback.getResult().getResult().get(0);
+        assertFalse(fromCache.getId().startsWith(TEMP_ID));
+        assertEquals(person.getId(), fromCache.getId());
+        testManager.push(store);
+        readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        fromCache = readCallback.getResult().getResult().get(0);
+        assertFalse(fromCache.getId().startsWith(TEMP_ID));
+        assertEquals(person.getId(), fromCache.getId());
+        assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
+    }
+
+    /* check that old temp item which was created without 'temp_' prefix
+    and item with 'temp_' prefix  will be pushed booth as expect */
+    @Test
+    public void testMixItemsWithOldAndNewTempIdPatterns() throws  InterruptedException {
+        store = DataStore.collection(Person.COLLECTION, Person.class, StoreType.SYNC, client);
+        testManager.cleanBackend(store, StoreType.SYNC);
+        Person person = new Person(TEST_USERNAME);
+        person.setId(UUID.randomUUID().toString());
+        Person person2 = new Person(TEST_USERNAME_2);
+        DefaultKinveyClientCallback saveCallback = testManager.save(store, person);
+        assertNotNull(saveCallback);
+        assertNull(saveCallback.getError());
+        assertNotNull(saveCallback.getResult());
+        Person savedPerson = saveCallback.getResult();
+        saveCallback = testManager.save(store, person2);
+        assertNotNull(saveCallback);
+        assertNull(saveCallback.getError());
+        assertNotNull(saveCallback.getResult());
+        Person savedPerson2 = saveCallback.getResult();
+        assertFalse(savedPerson.getId().startsWith(TEMP_ID));
+        assertEquals(person.getId(), savedPerson.getId());
+        assertTrue(savedPerson2.getId().startsWith(TEMP_ID));
+        assertEquals(person2.getId(), savedPerson2.getId());
+        DefaultKinveyReadCallback readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(2, readCallback.getResult().getResult().size());
+        assertEquals(2, client.getSyncManager().getCount(Person.COLLECTION));
+        readCallback = testManager.find(store, client.query().equals("username", TEST_USERNAME));
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        Person fromCache = readCallback.getResult().getResult().get(0);
+        assertFalse(fromCache.getId().startsWith(TEMP_ID));
+        assertEquals(person.getId(), fromCache.getId());
+        readCallback = testManager.find(store, client.query().equals("username", TEST_USERNAME_2));
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(1, readCallback.getResult().getResult().size());
+        Person fromCache2 = readCallback.getResult().getResult().get(0);
+        assertTrue(fromCache2.getId().startsWith(TEMP_ID));
+        assertEquals(person2.getId(), fromCache2.getId());
+        testManager.push(store);
+        readCallback = testManager.find(store, client.query());
+        assertNotNull(readCallback);
+        assertNull(readCallback.getError());
+        assertNotNull(readCallback.getResult().getResult());
+        assertEquals(2, readCallback.getResult().getResult().size());
+        assertFalse(readCallback.getResult().getResult().get(0).getId().startsWith(TEMP_ID));
+        assertFalse(readCallback.getResult().getResult().get(1).getId().startsWith(TEMP_ID));
+        assertEquals(0, client.getSyncManager().getCount(Person.COLLECTION));
+    }
+
+
+}

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
@@ -122,7 +122,7 @@ public class AsyncPushRequest<T extends GenericJson> extends AsyncClientRequest<
                     SyncItem syncItem = syncItems.get(j+i);
                     id = syncItem.getEntityID().id;
 
-                    switch (RequestMethod.fromString(syncItem.getRequestMethod())) {
+                    switch (syncItem.getRequestMethod()) {
                         case SAVE:
                             t = client.getCacheManager().getCache(collection, storeItemType, Long.MAX_VALUE).get(id);
                             if (t == null) {

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
@@ -123,6 +123,7 @@ public class AsyncPushRequest<T extends GenericJson> extends AsyncClientRequest<
                     id = syncItem.getEntityID().id;
 
                     switch (syncItem.getRequestMethod()) {
+                        case SAVE: // the SAVE case need for backward compatibility
                         case POST:
                         case PUT:
                             t = client.getCacheManager().getCache(collection, storeItemType, Long.MAX_VALUE).get(id);

--- a/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
+++ b/android-lib/src/main/java/com/kinvey/android/async/AsyncPushRequest.java
@@ -123,7 +123,8 @@ public class AsyncPushRequest<T extends GenericJson> extends AsyncClientRequest<
                     id = syncItem.getEntityID().id;
 
                     switch (syncItem.getRequestMethod()) {
-                        case SAVE:
+                        case POST:
+                        case PUT:
                             t = client.getCacheManager().getCache(collection, storeItemType, Long.MAX_VALUE).get(id);
                             if (t == null) {
                                 // check that item wasn't deleted before

--- a/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/ClassHash.java
@@ -59,6 +59,7 @@ public abstract class ClassHash {
     public static final String TTL = "__ttl__";
     private static final String ID = "_id";
     private static final String ITEMS = "_items";
+    private static final String TEMP_ID = "temp_";
 
     private static final HashSet<String> PRIVATE_FIELDS = new HashSet<String>(){
         {
@@ -520,7 +521,7 @@ public abstract class ClassHash {
                     .equalTo(ID, (String) obj.get(ID))
                     .findFirst();
         } else {
-            obj.put(ID, UUID.randomUUID().toString());
+            obj.put(ID, TEMP_ID + UUID.randomUUID().toString());
         }
 
         String kmdId = null;

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -463,7 +463,7 @@ public class NetworkManager<T extends GenericJson> {
     }
 
     public boolean isTempId(T item) {
-        boolean isTempId = true;
+        boolean isTempId = false;
         if (item.get(Constants._ID) != null) {
             try {
                 isTempId = item.get(Constants._ID).toString().startsWith("temp_");

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -466,7 +466,7 @@ public class NetworkManager<T extends GenericJson> {
         boolean isTempId = true;
         if (item.get(Constants._ID) != null) {
             try {
-                isTempId = item.get(Constants._ID).toString().matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
+                isTempId = item.get(Constants._ID).toString().startsWith("temp_");
             } catch (NullPointerException npe) {
                 // issue with the regex, so do nothing because we default to false
             }

--- a/java-api-core/src/com/kinvey/java/network/NetworkManager.java
+++ b/java-api-core/src/com/kinvey/java/network/NetworkManager.java
@@ -23,6 +23,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.kinvey.java.AbstractClient;
+import com.kinvey.java.Constants;
 import com.kinvey.java.Query;
 import com.kinvey.java.annotations.ReferenceHelper;
 import com.kinvey.java.cache.ICache;
@@ -448,14 +449,7 @@ public class NetworkManager<T extends GenericJson> {
             e.printStackTrace();
         }
 
-        boolean bRealmGeneratedId = false;
-
-        try {
-            bRealmGeneratedId = sourceID.matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
-        } catch (NullPointerException npe) {
-            // issue with the regex, so do nothing because we default to false
-            String msg = npe.getMessage();
-        }
+        boolean bRealmGeneratedId = isTempId(entity);
 
         if (sourceID != null && !bRealmGeneratedId) {
             save = new Save(entity, myClass, sourceID, SaveMode.PUT);
@@ -466,6 +460,18 @@ public class NetworkManager<T extends GenericJson> {
         client.initializeRequest(save);
 
         return save;
+    }
+
+    public boolean isTempId(T item) {
+        boolean isTempId = true;
+        if (item.get(Constants._ID) != null) {
+            try {
+                isTempId = item.get(Constants._ID).toString().matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
+            } catch (NullPointerException npe) {
+                // issue with the regex, so do nothing because we default to false
+            }
+        }
+        return isTempId;
     }
 
     /**

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -22,7 +22,6 @@ import com.kinvey.java.Constants;
 import com.kinvey.java.cache.ICache;
 import com.kinvey.java.core.KinveyJsonResponseException;
 import com.kinvey.java.network.NetworkManager;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncItem;
 import com.kinvey.java.sync.dto.SyncRequest;
@@ -90,7 +89,7 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
                         String tempID = syncRequest.getEntityID().id;
                         GenericJson result = syncManager.executeRequest(client, syncRequest);
                         T temp = cache.get(tempID);
-                        temp.set("_id", result.get("_id"));
+                        temp.set(Constants._ID, result.get(Constants._ID));
                         cache.delete(tempID);
                         cache.save(temp);
                     } else {

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -30,6 +30,8 @@ import com.kinvey.java.sync.dto.SyncRequest;
 import java.io.IOException;
 import java.util.List;
 
+import static com.kinvey.java.sync.dto.SyncRequest.HttpVerb.SAVE;
+
 /**
  * Created by Prots on 2/8/16.
  */
@@ -65,7 +67,7 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
             T t;
             for (SyncItem syncItem : syncItems) {
                 if (syncItem.getRequestMethod() != null) {
-                    switch (RequestMethod.fromString(syncItem.getRequestMethod())) {
+                    switch (syncItem.getRequestMethod()) {
                         case SAVE:
                             t = cache.get(syncItem.getEntityID().id);
                             if (t == null) {

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -30,7 +30,6 @@ import com.kinvey.java.sync.dto.SyncRequest;
 import java.io.IOException;
 import java.util.List;
 
-import static com.kinvey.java.sync.dto.SyncRequest.HttpVerb.SAVE;
 
 /**
  * Created by Prots on 2/8/16.
@@ -68,7 +67,8 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
             for (SyncItem syncItem : syncItems) {
                 if (syncItem.getRequestMethod() != null) {
                     switch (syncItem.getRequestMethod()) {
-                        case SAVE:
+                        case POST:
+                        case PUT:
                             t = cache.get(syncItem.getEntityID().id);
                             if (t == null) {
                                 // check that item wasn't deleted before

--- a/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/PushRequest.java
@@ -69,6 +69,7 @@ public class PushRequest<T extends GenericJson> extends AbstractKinveyExecuteReq
                 httpVerb = syncItem.getRequestMethod();
                 if (httpVerb != null) {
                     switch (httpVerb) {
+                        case SAVE: //the SAVE case need for backward compatibility
                         case POST:
                         case PUT:
                             t = cache.get(syncItem.getEntityID().id);

--- a/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteIdsRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteIdsRequest.java
@@ -23,8 +23,8 @@ import com.kinvey.java.cache.ICache;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.query.MongoQueryFilter;
 import com.kinvey.java.store.WritePolicy;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
+import com.kinvey.java.sync.dto.SyncRequest;
 
 import java.io.IOException;
 
@@ -54,6 +54,6 @@ public class DeleteIdsRequest<T extends GenericJson> extends AbstractDeleteReque
 
     @Override
     protected void enqueueRequest(String collectionName, NetworkManager<T> networkManager) throws IOException {
-        syncManager.enqueueRequests(collectionName, networkManager, RequestMethod.DELETE, ids);
+        syncManager.enqueueDeleteRequests(collectionName, networkManager, ids);
     }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteQueryRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteQueryRequest.java
@@ -21,7 +21,6 @@ import com.kinvey.java.Query;
 import com.kinvey.java.cache.ICache;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncRequest;
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteQueryRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteQueryRequest.java
@@ -23,6 +23,7 @@ import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
 import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
+import com.kinvey.java.sync.dto.SyncRequest;
 
 import java.io.IOException;
 
@@ -51,6 +52,6 @@ public class DeleteQueryRequest<T extends GenericJson> extends AbstractDeleteReq
 
     @Override
     protected void enqueueRequest(String collectionName, NetworkManager<T> networkManager) throws IOException {
-        syncManager.enqueueRequests(collectionName, networkManager, RequestMethod.DELETE, cache.get(query));
+        syncManager.enqueueDeleteRequests(collectionName, networkManager, cache.get(query));
     }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteSingleRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteSingleRequest.java
@@ -20,7 +20,6 @@ import com.google.api.client.json.GenericJson;
 import com.kinvey.java.cache.ICache;
 import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncRequest;
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteSingleRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/delete/DeleteSingleRequest.java
@@ -22,8 +22,10 @@ import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
 import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
+import com.kinvey.java.sync.dto.SyncRequest;
 
 import java.io.IOException;
+
 
 /**
  * Created by Prots on 2/15/16.
@@ -49,6 +51,6 @@ public class DeleteSingleRequest<T extends GenericJson> extends AbstractDeleteRe
 
     @Override
     protected void enqueueRequest(String collectionName, NetworkManager<T> networkManager) throws IOException {
-        syncManager.enqueueRequest(collectionName, networkManager, RequestMethod.DELETE, id);
+        syncManager.enqueueRequest(collectionName, networkManager, SyncRequest.HttpVerb.DELETE, id);
     }
 }

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListRequest.java
@@ -76,7 +76,7 @@ public class SaveListRequest<T extends GenericJson> implements IRequest<List<T>>
                         ret.add(networkManager.saveBlocking(object).execute());
                     } catch (IOException e) {
                         syncManager.enqueueRequest(networkManager.getCollectionName(),
-                                networkManager, isTempId(object) ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, (String)object.get(Constants._ID));
+                                networkManager, networkManager.isTempId(object) ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, (String)object.get(Constants._ID));
                         exception = e;
                     }
                 }
@@ -94,17 +94,6 @@ public class SaveListRequest<T extends GenericJson> implements IRequest<List<T>>
                 break;
         }
         return ret;
-    }
-
-    private boolean isTempId(T item) {
-        String tempID = item.get(Constants._ID).toString();
-        boolean isTempId = false;
-        try {
-            isTempId = tempID.matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
-        } catch (NullPointerException npe) {
-            // issue with the regex, so do nothing because we default to false
-        }
-        return isTempId;
     }
 
     @Override

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveListRequest.java
@@ -23,7 +23,6 @@ import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
 import com.kinvey.java.store.requests.data.IRequest;
 import com.kinvey.java.store.requests.data.PushRequest;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncRequest;
 

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.java
@@ -25,6 +25,7 @@ import com.kinvey.java.store.requests.data.IRequest;
 import com.kinvey.java.store.requests.data.PushRequest;
 import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
+import com.kinvey.java.sync.dto.SyncRequest;
 
 import java.io.IOException;
 
@@ -55,7 +56,7 @@ public class SaveRequest<T extends GenericJson> implements IRequest<T> {
             case FORCE_LOCAL:
                 ret = cache.save(object);
                 syncManager.enqueueRequest(networkManager.getCollectionName(),
-                        networkManager, RequestMethod.SAVE, (String)object.get(Constants._ID));
+                        networkManager, networkManager.isTempId(ret) ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, (String)object.get(Constants._ID));
                 break;
             case LOCAL_THEN_NETWORK:
                 PushRequest<T> pushRequest = new PushRequest<T>(networkManager.getCollectionName(), cache, networkManager,
@@ -73,30 +74,22 @@ public class SaveRequest<T extends GenericJson> implements IRequest<T> {
                 // result from the backend with the permanent _id, the record in the cache with the
                 // temporary _id should be removed, and the new record should be saved.
                 ret = cache.save(object);
-                String tempID = ret.get("_id").toString();
-                boolean bRealmGeneratedId = false;
-
-                try {
-                    bRealmGeneratedId = tempID.matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
-                    if (bRealmGeneratedId) {
-                        ret.set("_id", null);
-                    }
-                } catch (NullPointerException npe) {
-                    // issue with the regex, so do nothing because we default to false
-                    String msg = npe.getMessage();
+                String id = ret.get(Constants._ID).toString();
+                boolean bRealmGeneratedId = networkManager.isTempId(ret);
+                if (bRealmGeneratedId) {
+                    ret.set(Constants._ID, null);
                 }
-
                 try{
                     ret = networkManager.saveBlocking(object).execute();
                     if (bRealmGeneratedId) {
                         // The result from the network has the entity with its permanent ID. Need
                         // to remove the entity from the local cache with the temporary ID.
-                        cache.delete(tempID);
+                        cache.delete(id);
                     }
 
                 } catch (IOException e) {
                     syncManager.enqueueRequest(networkManager.getCollectionName(),
-                            networkManager, RequestMethod.SAVE, (String)object.get(Constants._ID));
+                            networkManager, bRealmGeneratedId ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, id);
                     throw e;
                 }
                 cache.save(ret);

--- a/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.java
+++ b/java-api-core/src/com/kinvey/java/store/requests/data/save/SaveRequest.java
@@ -23,7 +23,6 @@ import com.kinvey.java.network.NetworkManager;
 import com.kinvey.java.store.WritePolicy;
 import com.kinvey.java.store.requests.data.IRequest;
 import com.kinvey.java.store.requests.data.PushRequest;
-import com.kinvey.java.sync.RequestMethod;
 import com.kinvey.java.sync.SyncManager;
 import com.kinvey.java.sync.dto.SyncRequest;
 

--- a/java-api-core/src/com/kinvey/java/sync/SyncManager.java
+++ b/java-api-core/src/com/kinvey/java/sync/SyncManager.java
@@ -16,6 +16,7 @@
 
 package com.kinvey.java.sync;
 
+import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.json.GenericJson;
 import com.google.gson.Gson;
@@ -37,6 +38,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -129,7 +131,7 @@ public class SyncManager {
     }
 
     /**
-     * use {@link #enqueueRequest(String, NetworkManager, RequestMethod, String)}
+     * use {@link #enqueueRequest(String, NetworkManager, SyncItem.HttpVerb, String)}
      */
     @Deprecated
     public void enqueueRequest(String collectionName, AbstractKinveyJsonClientRequest clientRequest) throws IOException {
@@ -138,7 +140,7 @@ public class SyncManager {
     }
 
     /**
-     * use {@link #enqueueRequests(String, NetworkManager, RequestMethod, List)}
+     * use {@link #enqueueRequests(String, NetworkManager, SyncItem.HttpVerb, List)}
      */
     @Deprecated
     public <T extends GenericJson> void enqueueRequests(String collectionName, NetworkManager<T> networkManager,  List<T> ret) throws IOException {
@@ -159,22 +161,22 @@ public class SyncManager {
         requestCache.save(request);
     }
 
-    public <T extends GenericJson> void enqueueRequest(String collectionName, NetworkManager<T> networkManager, RequestMethod method, String id) throws IOException {
+    public <T extends GenericJson> void enqueueRequest(String collectionName, NetworkManager<T> networkManager, SyncItem.HttpVerb httpMethod, String id) throws IOException {
         ICache<SyncItem> requestCache = cacheManager.getCache(SYNC_ITEM_TABLE_NAME, SyncItem.class, Long.MAX_VALUE);
-        SyncItem syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, method, id);
+        SyncItem syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, httpMethod, id);
         if (syncItem != null) {
             requestCache.save(syncItem);
         }
     }
 
-    public <T extends GenericJson> void enqueueRequests(String collectionName, NetworkManager<T> networkManager, RequestMethod method, List<T> ret) throws IOException {
+    public <T extends GenericJson> void enqueueDeleteRequests(String collectionName, NetworkManager<T> networkManager, List<T> ret) throws IOException {
         ICache<SyncItem> requestCache = cacheManager.getCache(SYNC_ITEM_TABLE_NAME, SyncItem.class, Long.MAX_VALUE);
         List<SyncItem> syncRequests = new ArrayList<>();
         String syncItemId;
         SyncItem syncItem;
         for (T t : ret) {
             syncItemId = (String) t.get(ID);
-            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, method, syncItemId);
+            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, SyncRequest.HttpVerb.DELETE, syncItemId);
             if (syncItem != null) {
                 syncRequests.add(syncItem);
             }
@@ -182,12 +184,29 @@ public class SyncManager {
         requestCache.save(syncRequests);
     }
 
-    public <T extends GenericJson> void enqueueRequests(String collectionName, NetworkManager<T> networkManager, RequestMethod method, Iterable<String> ids) throws IOException {
+    public <T extends GenericJson> void enqueueSaveRequests(String collectionName, NetworkManager<T> networkManager, List<T> ret) throws IOException {
+        ICache<SyncItem> requestCache = cacheManager.getCache(SYNC_ITEM_TABLE_NAME, SyncItem.class, Long.MAX_VALUE);
+        List<SyncItem> syncRequests = new ArrayList<>();
+        String syncItemId;
+        SyncItem syncItem;
+        boolean isTempId = false;
+        for (T t : ret) {
+            syncItemId = (String) t.get(ID);
+            isTempId = syncItemId.matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
+            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, isTempId ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, syncItemId);
+            if (syncItem != null) {
+                syncRequests.add(syncItem);
+            }
+        }
+        requestCache.save(syncRequests);
+    }
+
+    public <T extends GenericJson> void enqueueDeleteRequests(String collectionName, NetworkManager<T> networkManager, Iterable<String> ids) throws IOException {
         ICache<SyncItem> requestCache = cacheManager.getCache(SYNC_ITEM_TABLE_NAME, SyncItem.class, Long.MAX_VALUE);
         List<SyncItem> syncRequests = new ArrayList<>();
         SyncItem syncItem;
         for (String syncItemId : ids) {
-            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, method, syncItemId);
+            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, SyncRequest.HttpVerb.DELETE, syncItemId);
             if (syncItem != null) {
                 syncRequests.add(syncItem);
             }
@@ -198,21 +217,21 @@ public class SyncManager {
     private <T extends GenericJson> SyncItem prepareSyncItemRequest(ICache<SyncItem> requestCache,
                                                                     String collectionName,
                                                                     NetworkManager<T> networkManager,
-                                                                    RequestMethod method,
+                                                                    SyncItem.HttpVerb httpMethod,
                                                                     String syncItemId) throws IOException {
         Query entityQuery = AbstractClient.sharedInstance().query();
         entityQuery.equals(META_DOT_ID, syncItemId);
         List<SyncItem> itemsList = requestCache.get(entityQuery);
         if (itemsList.isEmpty()) {
-            return createSyncItem(collectionName, method, networkManager, syncItemId);
-        } else if (method == RequestMethod.DELETE) {
+            return createSyncItem(collectionName, httpMethod, networkManager, syncItemId);
+        } else if (httpMethod == SyncRequest.HttpVerb.DELETE) {
             requestCache.delete(entityQuery);
-            return createSyncItem(collectionName, method, networkManager, syncItemId);
+            return createSyncItem(collectionName, httpMethod, networkManager, syncItemId);
         }
         return null;
     }
 
-    private SyncItem createSyncItem(String collectionName, RequestMethod requestMethod, NetworkManager networkManager, String id) throws IOException {
+    private SyncItem createSyncItem(String collectionName, SyncItem.HttpVerb httpMethod, NetworkManager networkManager, String id) throws IOException {
         SyncRequest.SyncMetaData entityID = new SyncRequest.SyncMetaData();
         if (id != null) {
             entityID.id = id;
@@ -220,7 +239,7 @@ public class SyncManager {
         entityID.customerVersion = networkManager.getClientAppVersion();
         entityID.customheader = networkManager.getCustomRequestProperties() != null ?
                 (String) networkManager.getCustomRequestProperties().get("X-Kinvey-Custom-Request-Properties") : null;
-        return new SyncItem(requestMethod, entityID, collectionName);
+        return new SyncItem(httpMethod, entityID, collectionName);
     }
 
     public SyncRequest createSyncRequest(String collectionName, AbstractKinveyJsonClientRequest clientRequest) throws IOException {

--- a/java-api-core/src/com/kinvey/java/sync/SyncManager.java
+++ b/java-api-core/src/com/kinvey/java/sync/SyncManager.java
@@ -189,11 +189,9 @@ public class SyncManager {
         List<SyncItem> syncRequests = new ArrayList<>();
         String syncItemId;
         SyncItem syncItem;
-        boolean isTempId = false;
         for (T t : ret) {
             syncItemId = (String) t.get(ID);
-            isTempId = syncItemId.matches("\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}");
-            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, isTempId ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, syncItemId);
+            syncItem = prepareSyncItemRequest(requestCache, collectionName, networkManager, networkManager.isTempId(t) ? SyncRequest.HttpVerb.POST : SyncRequest.HttpVerb.PUT, syncItemId);
             if (syncItem != null) {
                 syncRequests.add(syncItem);
             }

--- a/java-api-core/src/com/kinvey/java/sync/dto/SyncItem.java
+++ b/java-api-core/src/com/kinvey/java/sync/dto/SyncItem.java
@@ -1,7 +1,6 @@
 package com.kinvey.java.sync.dto;
 
 import com.google.api.client.util.Key;
-import com.kinvey.java.sync.RequestMethod;
 
 /**
  * Created by yuliya on 10/04/17.

--- a/java-api-core/src/com/kinvey/java/sync/dto/SyncItem.java
+++ b/java-api-core/src/com/kinvey/java/sync/dto/SyncItem.java
@@ -15,17 +15,17 @@ public class SyncItem extends SyncRequest{
     public SyncItem() {
     }
 
-    public SyncItem(RequestMethod requestMethod, SyncMetaData entityID, String collectionName) {
-        this.requestMethod = requestMethod.name();
+    public SyncItem(SyncItem.HttpVerb httpMethod, SyncMetaData entityID, String collectionName) {
+        this.requestMethod = httpMethod.name();
         this.id = entityID;
         this.collectionName = collectionName;
     }
 
-    public String getRequestMethod() {
-        return requestMethod;
+    public SyncItem.HttpVerb getRequestMethod() {
+        return SyncItem.HttpVerb.fromString(requestMethod);
     }
 
-    public void setRequestMethod(String requestMethod) {
-        this.requestMethod = requestMethod;
+    public void setRequestMethod(SyncItem.HttpVerb requestMethod) {
+        this.requestMethod = requestMethod.name();
     }
 }

--- a/java-api-core/src/com/kinvey/java/sync/dto/SyncRequest.java
+++ b/java-api-core/src/com/kinvey/java/sync/dto/SyncRequest.java
@@ -36,6 +36,7 @@ public class SyncRequest extends GenericJson implements Serializable {
         PUT("PUT"),
         POST("POST"),
         DELETE("DELETE"),
+        SAVE("SAVE"), // for backward compatibility with previous versions of keeping Sync requests
         QUERY("QUERY");
 
         private String query;


### PR DESCRIPTION
#### Description
Right now, requests for the sync queue are only being saved as a SAVE or DELETE. It would be better to expose out what type of request we are pursuing (POST/PUT/DELETE) in the queue itself, in order to be able to replace temporary IDs with permanent IDs easier.

#### Changes
Changed sync items types from `SAVE or DELETE` to `POST/PUT/DELETE`. `SAVE` type was saved for backward compatibility with previous implementation.

#### Tests
Instrumented
