### PR TITLE
feat: MLIBZ-2577 Using Auto-pagination does not delete all items in the cache

### DIFF
--- a/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
+++ b/java-api-core/src/com/kinvey/java/store/BaseDataStore.java
@@ -502,12 +502,14 @@ public class BaseDataStore<T extends GenericJson> {
         List<FutureTask<PullTaskResponse>> tasks;
         NetworkManager.Get pullRequest;
         FutureTask<PullTaskResponse> ft;
+        cache.delete(query.setSkip(0).setLimit(0));// To be sure that skip and limit are 0,
+        // because in next lines custom skip and limit are set anyway
         for (int i = 0; i < totalPagesNumber; i += batchSize) {
             executor = Executors.newFixedThreadPool(batchSize);
             tasks = new ArrayList<>();
             do {
                 query.setSkip(skipCount).setLimit(pageSize);
-                pullRequest = networkManager.pullBlocking(query);
+                pullRequest = networkManager.getBlocking(query);
                 skipCount += pageSize;
                 try {
                     ft = new FutureTask<PullTaskResponse>(new CallableAsyncPullRequestHelper(pullRequest, query));
@@ -524,7 +526,6 @@ public class BaseDataStore<T extends GenericJson> {
             for (FutureTask<PullTaskResponse> task : tasks) {
                 try {
                     PullTaskResponse tempResponse = task.get();
-                    cache.delete(tempResponse.getQuery());
                     pulledItemCount += cache.save(tempResponse.getKinveyReadResponse().getResult()).size();
                     exceptions.addAll(tempResponse.getKinveyReadResponse().getListOfExceptions());
                     if (lastRequestTime == null) { //it will be changed to time from count request
@@ -536,6 +537,7 @@ public class BaseDataStore<T extends GenericJson> {
             }
             executor.shutdown();
         }
+        query.setSkip(0).setLimit(0); // To set back default value of skip and limit
         response.setListOfExceptions(exceptions);
         response.setCount(pulledItemCount);
         if (deltaSetCachingEnabled && lastRequestTime != null) {


### PR DESCRIPTION
#### Description
Steps to reproduce:

1. Create 5 items with some property value - e.g. name = name1
2. Create 3000 items with another value - e.g. name = name2
3. Pull() or Sync() with AP = 1000
4. Check the db - all 3005 items should be there
5. Delete all items with name=name2 from the backend
6. Pull() or Sync() with AP=1000

Expected result: All 3000 items with name=name2 are deleted from the cache

Actual result: The AP pull gets only the 5 items with name = name1, which were not deleted from the backend. Not all items with name =name2, however, are deleted from cache. The number of actually deleted items from the cache = the AP size(1000) - the result of the _count request from the AP pull() - in our case 5. So from all 3005 items, after the pull from step 6, there are 2005 items in the cache, the next pull with AP = 1000 will delete another 1000-5 items.

#### Changes
Added deleting all items by query from the cache before auto-paginated concurrent pull. 

#### Tests
Instrumented
