### PR TITLE
feat: MLIBZ-2553 Exception in the logs after getting error from the backend

### DIFF
--- a/java-api-core/src/com/kinvey/java/core/KinveyJsonError.java
+++ b/java-api-core/src/com/kinvey/java/core/KinveyJsonError.java
@@ -23,6 +23,8 @@ import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Key;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
 
 /**
  *
@@ -53,6 +55,19 @@ public class KinveyJsonError extends GenericData {
   public static KinveyJsonError parse(JsonFactory jsonFactory, HttpResponse response) throws IOException {
     return new JsonObjectParser(jsonFactory).parseAndClose(response.getContent(),
         response.getContentCharset(), KinveyJsonError.class);
+  }
+
+  /**
+   * Parses the HttpResponse as a standard Kinvey error.
+   *
+   * @param jsonFactory the json factory to use while parsing
+   * @param content
+   * @param charset
+   * @return standard error object
+   * @throws IOException error occurred during parse
+   */
+  public static KinveyJsonError parse(JsonFactory jsonFactory, InputStream content, Charset charset) throws IOException {
+    return new JsonObjectParser(jsonFactory).parseAndClose(content, charset, KinveyJsonError.class);
   }
 
   /**

--- a/java-api-core/src/com/kinvey/java/core/KinveyJsonResponseException.java
+++ b/java-api-core/src/com/kinvey/java/core/KinveyJsonResponseException.java
@@ -22,87 +22,97 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonParser;
+import com.google.common.io.Closer;
 import com.kinvey.java.KinveyException;
+import com.kinvey.java.store.file.FileUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * @author m0rganic
- *
  */
 public class KinveyJsonResponseException extends HttpResponseException {
 
-  /** **/
-  private static final long serialVersionUID = -5586707180518343613L;
-  
-  private final KinveyJsonError details;
+    /** **/
+    private static final long serialVersionUID = -5586707180518343613L;
 
-  private final String message;
+    private final KinveyJsonError details;
+
+    private final String message;
 
     /**
-     *
      * @param response raw http response
-     * @param details detail message give by the response
-     * @param message general message
+     * @param details  detail message give by the response
+     * @param message  general message
      */
-  private KinveyJsonResponseException(HttpResponse response, KinveyJsonError details, String message) {
-    super(response);
-    this.details = details;
-    this.message = message;
-  }
-  
+    private KinveyJsonResponseException(HttpResponse response, KinveyJsonError details, String message) {
+        super(response);
+        this.details = details;
+        this.message = message;
+    }
 
 
     /**
      * @param jsonFactory json factory to use while parsing the response
-     * @param response raw http response
+     * @param response    raw http response
      * @return exception object built up from the raw http response
      */
-  public static KinveyJsonResponseException from(JsonFactory jsonFactory, HttpResponse response) {
-    KinveyJsonError details = null;
-    try {
-      if (!response.isSuccessStatusCode()
-          && HttpMediaType.equalsIgnoreParameters(Json.MEDIA_TYPE, response.getContentType())
-          && response.getContent() != null) {
-        JsonParser parser = null;
+    public static KinveyJsonResponseException from(JsonFactory jsonFactory, HttpResponse response) {
+        KinveyJsonResponseException kinveyJsonResponseException = null;
+        KinveyJsonError details = null;
         try {
-          parser = jsonFactory.createJsonParser(response.getContent());
-          details = KinveyJsonError.parse(jsonFactory, response);
-        } catch (Exception e) {
-        	throw new KinveyException("Unable to parse the JSON in the response", 
-        			"examine BL or DLC to ensure data format is correct. If the exception is caused by `key <somkey>`, then <somekey> might be a different type than is expected (int instead of of string)",
-        			e.toString());
-        } finally {
-          if (parser == null) {
-            response.ignore();
-          } else if (details == null) {
-            parser.close();
-          }
+            if (!response.isSuccessStatusCode()
+                    && HttpMediaType.equalsIgnoreParameters(Json.MEDIA_TYPE, response.getContentType())
+                    && response.getContent() != null) {
+                JsonParser parser = null;
+                Closer closer = Closer.create();
+                try {
+                    ByteArrayOutputStream outputStream = closer.register(new ByteArrayOutputStream());
+                    FileUtils.copyStreams(response.getContent(), outputStream);
+                    InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+                    parser = jsonFactory.createJsonParser(response.getContent());
+                    details = KinveyJsonError.parse(jsonFactory, inputStream, response.getContentCharset());
+                } catch (Exception e) {
+                    throw new KinveyException("Unable to parse the JSON in the response",
+                            "examine BL or DLC to ensure data format is correct. If the exception is caused by `key <somkey>`, then <somekey> might be a different type than is expected (int instead of of string)",
+                            e.toString());
+                } finally {
+                    if (parser == null) {
+                        response.ignore();
+                    } else if (details == null) {
+                        parser.close();
+                    }
+                    closer.close();
+                }
+            }
+        } catch (IOException exception) {
+            // it would be bad to throw an exception while throwing an exception
+            exception.printStackTrace();
         }
-      }
-    } catch (IOException exception) {
-      // it would be bad to throw an exception while throwing an exception
-     // exception.printStackTrace();
+
+        String detailMessage =
+                (details == null ? "unknown" : String.format("%s%n%s", details.getError(),
+                        details.getDescription()));
+
+        kinveyJsonResponseException = new KinveyJsonResponseException(response, details, detailMessage);
+
+        return kinveyJsonResponseException;
     }
 
-    String detailMessage =
-        (details == null ? "unknown" : String.format("%s%n%s", details.getError(),
-            details.getDescription()));
-    
-    return new KinveyJsonResponseException(response, details, detailMessage);
-  }
-
-  /**
-   * @return the details
-   */
-  public KinveyJsonError getDetails() {
-    return this.details;
-  }
+    /**
+     * @return the details
+     */
+    public KinveyJsonError getDetails() {
+        return this.details;
+    }
 
     /**
      * @return the message
      */
-    public String getMessage(){
+    public String getMessage() {
         return this.message;
     }
 


### PR DESCRIPTION
#### Description
When the SDK gets an error from the backend like `MissingConfiguration`, we have in stacktrace this log:
```
W/System.err: java.io.IOException: closed
        at com.android.okio.RealBufferedSource$1.read(RealBufferedSource.java:167)
        at java.io.FilterInputStream.read(FilterInputStream.java:118)
        at com.google.api.client.util.LoggingInputStream.read(LoggingInputStream.java:57)
        at java.io.InputStream.read(InputStream.java:162)
        at com.google.api.client.util.ByteStreams.copy(ByteStreams.java:51)
        at com.google.api.client.util.IOUtils.copy(IOUtils.java:94)
        at com.google.api.client.util.IOUtils.copy(IOUtils.java:63)
        at com.google.api.client.http.HttpResponse.parseAsString(HttpResponse.java:515)
```
The SDK tries to read context from response twice, but it was closed after the first attempt. It doesn't affect any functionality.

#### Changes
Added copying response stream for correct creating KinveyJsonResponseException.

#### Tests
Manual testing. The testing is manual because we see the bug just in the stack trace, the exception is just printed in the stack trace, it isn't thrown, from the HttpResponseException class. The class is from the external library `com.google.api.client.http`.