### PR TITLE
feat: MLIBZ-2609 Increase code coverage of cache source files

### DIFF
--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/CacheTest.java
@@ -195,4 +195,11 @@ public class CacheTest {
         }
 
     }
+
+    @Test
+    public void testGetTTL() {
+        long ttl = 123456L;
+        assertEquals(ttl, cacheManager.getCache("testInnerWithList3", SampleGsonWithInnerList.class, ttl).getTtl());
+    }
+
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/QueryTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/cache/QueryTest.java
@@ -25,12 +25,14 @@ import io.realm.RealmQuery;
 import io.realm.Sort;
 
 import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by Prots on 30/01/16.
@@ -433,4 +435,15 @@ public class QueryTest {
         verify(query, times(3)).endGroup();
     }
 
+    @Test
+    public void testUnsupportedOperationException() {
+        Query q = new Query();
+        q.startsWith(TEST_FIELD, 1);
+        try {
+            QueryHelper.prepareRealmQuery(query, q.getQueryFilterMap());
+        } catch (UnsupportedOperationException e) {
+            assertEquals("this query is not supported by cache", e.getMessage());
+        }
+    }
+    
 }

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/EntityForInQueryTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/EntityForInQueryTest.java
@@ -1,0 +1,60 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+public class EntityForInQueryTest extends GenericJson{
+
+    public static final String COLLECTION = "InQueryTestCollection";
+
+    @Key
+    private long longVal;
+    @Key
+    private String stringVal;
+    @Key
+    private boolean booleanVal;
+    @Key
+    private int intVal;
+    @Key
+    private float floatVal;
+
+    public long getLongVal() {
+        return longVal;
+    }
+
+    public void setLongVal(long longVal) {
+        this.longVal = longVal;
+    }
+
+    public String getStringVal() {
+        return stringVal;
+    }
+
+    public void setStringVal(String stringVal) {
+        this.stringVal = stringVal;
+    }
+
+    public boolean isBooleanVal() {
+        return booleanVal;
+    }
+
+    public void setBooleanVal(boolean booleanVal) {
+        this.booleanVal = booleanVal;
+    }
+
+    public int getIntVal() {
+        return intVal;
+    }
+
+    public void setIntVal(int intVal) {
+        this.intVal = intVal;
+    }
+
+    public float getFloatVal() {
+        return floatVal;
+    }
+
+    public void setFloatVal(float floatVal) {
+        this.floatVal = floatVal;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/LongPrimitiveListInPerson.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/LongPrimitiveListInPerson.java
@@ -1,0 +1,26 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.util.Key;
+
+import java.util.List;
+
+public class LongPrimitiveListInPerson extends Person {
+
+    @Key("longList")
+    private List<Long> longList;
+
+    public LongPrimitiveListInPerson() {
+    }
+
+    public LongPrimitiveListInPerson(String username) {
+        this.username = username;
+    }
+
+    public List<Long> getLongList() {
+        return longList;
+    }
+
+    public void setLongList(List<Long> longList) {
+        this.longList = longList;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/ModelWithDifferentTypeFields.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/ModelWithDifferentTypeFields.java
@@ -1,0 +1,101 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+import java.util.Date;
+
+public class ModelWithDifferentTypeFields extends GenericJson {
+
+    public static final String COLLECTION = "CustomCollection";
+
+    @Key("_id")
+    protected String id;
+
+
+    @Key
+    protected String username;
+
+    @Key
+    private int carNumber ;
+
+    @Key
+    private boolean isUseAndroid;
+
+    @Key
+    private Date date;
+
+    @Key
+    private float height;
+
+    @Key
+    private double time;
+
+    public ModelWithDifferentTypeFields() {
+    }
+
+    public ModelWithDifferentTypeFields(String username, int carNumber, boolean isUseAndroid, Date date, float height, double time) {
+        this.username = username;
+        this.carNumber = carNumber;
+        this.isUseAndroid = isUseAndroid;
+        this.date = date;
+        this.height = height;
+        this.time = time;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public int getCarNumber() {
+        return carNumber;
+    }
+
+    public void setCarNumber(int carNumber) {
+        this.carNumber = carNumber;
+    }
+
+    public boolean isUseAndroid() {
+        return isUseAndroid;
+    }
+
+    public void setUseAndroid(boolean useAndroid) {
+        isUseAndroid = useAndroid;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public float getHeight() {
+        return height;
+    }
+
+    public void setHeight(float height) {
+        this.height = height;
+    }
+
+    public double getTime() {
+        return time;
+    }
+
+    public void setTime(double time) {
+        this.time = time;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonArray.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/model/PersonArray.java
@@ -1,0 +1,39 @@
+package com.kinvey.androidTest.model;
+
+import com.google.api.client.util.Key;
+
+import java.util.List;
+
+public class PersonArray extends Person {
+
+    public static final String COLLECTION = "PersonArray";
+
+    @Key
+    private PersonArray[] array;
+
+    @Key
+    private PersonArray personArray;
+
+    public PersonArray() {
+    }
+
+    public PersonArray(String name) {
+        this.username = name;
+    }
+
+    public PersonArray[] getArray() {
+        return array;
+    }
+
+    public void setArray(PersonArray[] array) {
+        this.array = array;
+    }
+
+    public PersonArray getPersonArray() {
+        return personArray;
+    }
+
+    public void setPersonArray(PersonArray personArray) {
+        this.personArray = personArray;
+    }
+}

--- a/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
+++ b/android-lib/src/androidTest/java/com/kinvey/androidTest/store/DataStoreTest.java
@@ -22,6 +22,7 @@ import com.kinvey.android.model.User;
 import com.kinvey.android.store.DataStore;
 import com.kinvey.android.store.UserStore;
 import com.kinvey.android.sync.KinveyPullCallback;
+import com.kinvey.androidTest.model.PersonArray;
 import com.kinvey.java.model.KinveyPullResponse;
 import com.kinvey.android.sync.KinveyPushCallback;
 import com.kinvey.android.sync.KinveyPushResponse;
@@ -2566,6 +2567,53 @@ public class DataStoreTest {
         assertNotNull(deleteCallback.getResult());
         assertNull(deleteCallback.getError());
     }
+
+// filed as MLIBZ-2647
+/*
+    @Test
+    public void testSelfReferenceClassInClassWithArray() throws InterruptedException {
+        Context mMockContext = new RenamingDelegatingContext(InstrumentationRegistry.getInstrumentation().getTargetContext(), "test_");
+        client = new Client.Builder(mMockContext).build();
+        client.enableDebugLogging();
+        TestManager<PersonArray> testManager = new TestManager<>();
+        testManager.login(TestManager.USERNAME, TestManager.PASSWORD, client);
+        DataStore<PersonArray> store = DataStore.collection(PersonArray.COLLECTION, PersonArray.class, StoreType.SYNC, client);
+        assertNotNull(store);
+
+        PersonArray person1 = new PersonArray("person1");
+        PersonArray person2 = new PersonArray("person2");
+        PersonArray person3 = new PersonArray("person3");
+        PersonArray person4 = new PersonArray("person4");
+        PersonArray person5 = new PersonArray("person5");
+        PersonArray person6 = new PersonArray("person6");
+
+        PersonArray[] array = new PersonArray[4];
+        array[0] = person3;
+        array[1] = person4;
+        array[2] = person5;
+        array[3] = person6;
+        person2.setArray(array);
+
+        person1.setPersonArray(person2);
+
+        CustomKinveyClientCallback<PersonArray> callback = testManager.saveCustom(store, person1);
+        assertNotNull(callback.getResult());
+        assertNull(callback.getError());
+
+        CustomKinveyReadCallback<PersonArray> listCallback = testManager.findCustom(store, client.query());
+        assertNotNull(listCallback.getResult());
+        assertNull(listCallback.getError());
+
+        PersonArray person = listCallback.getResult().getResult().get(0);
+        assertEquals(person.getUsername(), "person1");
+        assertEquals(person.getPersonArray().getUsername(), "person2");
+        assertEquals(person.getPersonArray().getArray()[0].getUsername(), "person3");
+
+        com.kinvey.androidTest.callback.DefaultKinveyDeleteCallback deleteCallback = testManager.deleteCustom(store, client.query());
+        assertNotNull(deleteCallback.getResult());
+        assertNull(deleteCallback.getError());
+    }
+*/
 
     @Test
     public void testSelfReferenceBookAuthorBook() throws InterruptedException {

--- a/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
+++ b/android-lib/src/main/java/com/kinvey/android/cache/RealmCache.java
@@ -269,20 +269,6 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
         return i;
     }
 
-    /**
-     * Method gets item ids in support tables (_acl and _kmd)
-     * @param items items for getting them ids
-     * @param field _acl or _kmd
-     * @return item ids in support tables
-     */
-    private List<String> getSupportIds(List<T> items, String field) {
-        List<String> supportIds = new ArrayList<>();
-        for (T item : items) {
-            supportIds.add(getSupportId(item, field));
-        }
-        return supportIds;
-    }
-
     private int delete(DynamicRealm realm, Query query, String tableName) {
 
         int ret;
@@ -392,10 +378,6 @@ public class RealmCache<T extends GenericJson> implements ICache<T> {
             realm.close();
         }
         return i;
-    }
-
-    private String getSupportId(T item, String field) {
-        return item.get(field) != null ? ((String) ((GenericJson) item.get(field)).get(ID)) : null;
     }
 
     public String getCollection() {


### PR DESCRIPTION
#### Description
Increase code coverage of /cache source files

#### Changes
Added tests for  RealmCache class, some bugs were filed for this class: `MLIBZ-2644`, `MLIBZ-2647`. 
ClassHash contains untested only migration methods and one unused untested method.
QueryHelper's methods have tests except for tests for exceptions which can be thrown from reflection call, we can't add tests for them.
RealmCacheManager contains untested only migration methods.
TableNameManager doesn't have untested methods.
  
#### Tests
Instrumented
